### PR TITLE
autoreport status and limits, auto-generate homing linenumbers

### DIFF
--- a/limits.h
+++ b/limits.h
@@ -33,6 +33,8 @@ extern limit_t limits;
 
 // Initialize the limits module
 void limits_init();
+// Configure the limit enable/disable state
+void limits_configure();
 
 void limits_enable(uint8_t axes,uint8_t expected);
 void limits_disable();

--- a/motion_control.c
+++ b/motion_control.c
@@ -34,7 +34,7 @@
 #include "report.h"
 #include "counters.h"
 
-#define PROBE_LINE_NUMBER (LINENUMBER_SPECIAL|2)
+#define PROBE_LINE_NUMBER (LINENUMBER_SPECIAL)
 
 
 // Execute linear motion in absolute millimeter coordinates. Feed rate given in millimeters/second
@@ -255,7 +255,7 @@ void mc_homing_cycle(uint8_t axis_mask)
   st_go_idle(); // Set idle state after homing completes
 
   // If hard limits feature enabled, re-enable hard limits pin change register after homing cycle.
-  limits_init();
+  limits_configure();
 }
 
 

--- a/report.c
+++ b/report.c
@@ -413,7 +413,7 @@ uint8_t report_realtime_status()
   // to be added are distance to go on block, processed block id, and feed rate. Also a settings bitmask
   // for a user to select the desired real-time data.
   int32_t current_position[N_AXIS]; // Copy current state of the system position variable
-  linenumber_t ln=0;
+  static linenumber_t ln=0;
   uint8_t i;
   memcpy(current_position,sys.position,sizeof(sys.position));
 

--- a/settings.c
+++ b/settings.c
@@ -219,7 +219,7 @@ uint8_t settings_store_global_setting(int parameter, float value) {
     case 27:
       if (value) { settings.flags |= BITFLAG_HARD_LIMIT_ENABLE; }
       else { settings.flags &= ~BITFLAG_HARD_LIMIT_ENABLE; }
-      limits_init(); // Re-init to immediately change. NOTE: Nice to have but could be problematic later.
+      limits_configure(); // Re-init to immediately change. NOTE: Nice to have but could be problematic later.
       break;
     case 28:
       if (value) { settings.flags |= BITFLAG_HOMING_ENABLE; }

--- a/sim/avr/interrupt.h
+++ b/sim/avr/interrupt.h
@@ -32,6 +32,7 @@
 void interrupt_TIMER0_COMPA_vect();
 void interrupt_TIMER1_COMPA_vect();
 void interrupt_TIMER0_OVF_vect();
+void interrupt_TIMER2_COMPA_vect();
 void interrupt_SERIAL_UDRE();
 void interrupt_SERIAL_RX();
 void interrupt_LIMIT_INT_vect();

--- a/sim/simulator.c
+++ b/sim/simulator.c
@@ -65,6 +65,7 @@ void init_simulator(float time_multiplier) {
   //register the interrupt handlers we actually use.
   compa_vect[1] = interrupt_TIMER1_COMPA_vect;
   ovf_vect[0] = interrupt_TIMER0_OVF_vect;
+  compa_vect[2] = interrupt_TIMER2_COMPA_vect;
 #ifdef STEP_PULSE_DELAY
   compa_vect[0] = interrupt_TIMER0_COMPA_vect;
 #endif


### PR DESCRIPTION
This change causes grbl to continuously report status.  
This version works with the current interface.  The next phase is to combine some of the remaining messages, which will simplify the parser.
