### PR TITLE
Force Servo Process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,13 @@ FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 # Tune the lines below only if you know what you are doing:
 
 AVRDUDE = avrdude  $(PROGRAMMER) -p $(DEVICE) -B 10 -F -D
-COMPILE = avr-gcc -Wall -Os -DF_CPU=$(CLOCK) -mmcu=$(DEVICE) -I. -ffunction-sections
+CFLAGS = -Wall -Os -DF_CPU=$(CLOCK) -mmcu=$(DEVICE)
+COMPILE = avr-gcc $(CFLAGS) -I. -ffunction-sections
 
 # symbolic targets:
-all:	grbl.hex
+all debug:	grbl.hex
+
+debug:	CFLAGS += -g
 
 .c.o:
 	$(COMPILE) -c $< -o $@

--- a/limits.c
+++ b/limits.c
@@ -135,18 +135,27 @@ void limits_go_home(uint8_t cycle_mask)
       min_seek_rate = min(min_seek_rate,settings.homing_seek_rate[idx]);
     }
   }
+
+  /************DEBUG VALUE**************/
+  //max_travel_Debug = max_travel;
+  /***************/
+
   max_travel *= HOMING_AXIS_SEARCH_SCALAR; // Ensure homing switches engaged by over-estimating max travel.
   max_travel += settings.homing_pulloff;
   homing_rate = min_seek_rate * sqrt(n_active_axis); //Adjust so individual axes all move at homing rate.
 
   plan_reset(); // Reset planner buffer to zero planner current position and to clear previous motions.
-
+   
+  /************DEBUG VALUE**************/
+  //homing_rate_Debug = homing_rate;
+  //homing_pulloff_Debug = settings.homing_pulloff; 
+  /***************/
   do {
     // Set target location and rate for active axes.
     // and reset homing axis locks based on cycle mask.
 
     // limit travel away from the switch to the pulloff distance.
-    float travel = approach ? max_travel : settings.homing_pulloff;
+    float travel = approach ? max_travel : (40.0*settings.homing_pulloff); //40mm is length of largest flag (should make into parameter in header file)
     // set target for moving axes based on direction
     for (idx=0; idx<N_AXIS; idx++) {
       if (bit_istrue(cycle_mask,bit(idx))) {
@@ -173,6 +182,10 @@ void limits_go_home(uint8_t cycle_mask)
     st_wake_up(); // Initiate motion
 
     do {
+      /********DEBUG VALUE*******/
+      //test1Val++;
+      /**************************/
+
       st_prep_buffer(); // Check and prep segment buffer. NOTE: Should take no longer than 200us.
       // Check only for user reset. Keyme: fixed to allow protocol_execute_runtime() in this loop.
       protocol_execute_runtime();
@@ -191,6 +204,10 @@ void limits_go_home(uint8_t cycle_mask)
     } while (limits.ishoming);  //stepper isr sets this when limit is hit
 
     limits_disable();
+    /****DEBUG VALUE*****/
+    //test1Val=0;
+    /********************/
+    
     st_reset(); // Immediately force kill steppers and reset step segment buffer.
     plan_reset(); // Reset planner buffer. Zero planner positions. Ensure homing motion is cleared.
 

--- a/limits.c
+++ b/limits.c
@@ -135,7 +135,6 @@ void limits_go_home(uint8_t cycle_mask)
       min_seek_rate = min(min_seek_rate,settings.homing_seek_rate[idx]);
     }
   }
-
   max_travel *= HOMING_AXIS_SEARCH_SCALAR; // Ensure homing switches engaged by over-estimating max travel.
   max_travel += settings.homing_pulloff;
   homing_rate = min_seek_rate * sqrt(n_active_axis); //Adjust so individual axes all move at homing rate.
@@ -147,7 +146,6 @@ void limits_go_home(uint8_t cycle_mask)
 
     // limit travel distance to the length of the largest flag
     float travel = approach ? max_travel : MAXFLAGLEN;
-    
     // set target for moving axes based on direction
     for (idx=0; idx<N_AXIS; idx++) {
       if (bit_istrue(cycle_mask,bit(idx))) {
@@ -174,10 +172,6 @@ void limits_go_home(uint8_t cycle_mask)
     st_wake_up(); // Initiate motion
 
     do {
-      /********DEBUG VALUE*******/
-      //test1Val++;
-      /**************************/
-
       st_prep_buffer(); // Check and prep segment buffer. NOTE: Should take no longer than 200us.
       // Check only for user reset. Keyme: fixed to allow protocol_execute_runtime() in this loop.
       protocol_execute_runtime();
@@ -196,10 +190,6 @@ void limits_go_home(uint8_t cycle_mask)
     } while (limits.ishoming);  //stepper isr sets this when limit is hit
 
     limits_disable();
-    /****DEBUG VALUE*****/
-    //test1Val=0;
-    /********************/
-    
     st_reset(); // Immediately force kill steppers and reset step segment buffer.
     plan_reset(); // Reset planner buffer. Zero planner positions. Ensure homing motion is cleared.
 

--- a/limits.h
+++ b/limits.h
@@ -26,11 +26,15 @@
 // This is defined by the largest homing flag in the system. The Y flag is
 // the largest with a length of just under 40 mm.
 #define MAXFLAGLEN 40.0
+// Travel distance for the gripper from home is around 12 mm. Travel distane for gripping key is usually around 2-3 mm.
+#define MAXSERVODIST 12.0
+#define AXISLOCKSERVO 0x4
 
 typedef struct {
   uint8_t expected;
   uint8_t active;
   volatile uint8_t ishoming;
+  volatile uint8_t isservoing;
 } limit_t;
 
 extern limit_t limits;
@@ -49,4 +53,7 @@ void limits_go_home(uint8_t cycle_mask);
 // Check for soft limit violations
 void limits_soft_check(float *target);
 
+// Perform force servo cycle
+void limits_force_servo();
+float travel_servo;
 #endif

--- a/motion_control.h
+++ b/motion_control.h
@@ -34,16 +34,19 @@ void mc_line(float *target, float feed_rate, uint8_t invert_feed_rate, linenumbe
 void mc_arc(float *position, float *target, float *offset, float radius, float feed_rate, 
   uint8_t invert_feed_rate, uint8_t axis_0, uint8_t axis_1, uint8_t axis_linear, linenumber_t line_number);
   
-// Dwell for a specific number of seconds
-void mc_dwell(float seconds);
-
 // Perform homing cycle to locate machine zero. Requires limit switches.
 void mc_homing_cycle(uint8_t axis_mask);
+
+// Dwell for a specific number of seconds
+void mc_dwell(float seconds);
 
 // Perform tool length probe cycle. Requires probe switch.
 void mc_probe_cycle(float *target, float feed_rate, uint8_t invert_feed_rate, linenumber_t line_number);
 
 // Performs system reset. If in motion state, kills all motion and sets system alarm.
 void mc_reset();
+
+// Perform force servoing cycle. This moves the gripper motor to reach a desired force sensor value.
+void mc_force_servo_cycle();
 
 #endif

--- a/protocol.c
+++ b/protocol.c
@@ -271,8 +271,8 @@ void protocol_execute_runtime()
     }
 
     // Execute a cycle start by starting the stepper interrupt begin executing the blocks in queue.
-    // block Start while homing.
-    if ((rt_exec & EXEC_CYCLE_START) && !(sys.state & STATE_HOMING)) {
+    // block Start while homing/force-servoing.
+    if ((rt_exec & EXEC_CYCLE_START) && !(sys.state & STATE_HOMING) && !(sys.state & STATE_FORCESERVO)) {
       if (sys.state == STATE_QUEUED) {
         sys.state = STATE_CYCLE;
         st_prep_buffer(); // Initialize step segment buffer before beginning cycle.
@@ -303,7 +303,10 @@ void protocol_execute_runtime()
   // are runtime and require a direct and controlled interface to the main stepper program.
 
   // Reload step segment buffer
-  if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING)) { st_prep_buffer(); }
+  if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING | STATE_FORCESERVO))
+  { st_prep_buffer(); }
+
+  calculate_force_voltage();
 
   // Clear IO Reset bit.
   IO_RESET_PORT &= (~IO_RESET_MASK);

--- a/report.c
+++ b/report.c
@@ -508,6 +508,24 @@ uint8_t report_realtime_status()
   printPgmString(PSTR(":"));
   printInteger(ln);
   printPgmString(PSTR(">\r\n"));
+  
+  /*printPgmString(PSTR("test1Val: "));
+  print_uint32_base10(test1Val);
+  printPgmString(PSTR("\r\n"));
+
+  printPgmString(PSTR("max_travel: "));
+  printFloat_SettingValue(max_travel_Debug);
+  printPgmString(PSTR("\r\n"));
+
+  printPgmString(PSTR("homing_rate: "));
+  printFloat_RateValue(homing_rate_Debug);
+  printPgmString(PSTR("\r\n"));
+
+  printPgmString(PSTR("homing_pulloff: "));
+  printFloat_SettingValue(homing_pulloff_Debug);
+  printPgmString(PSTR("\r\n"));
+  */
+
 
   return (sys.flags & SYSFLAG_EOL_REPORT); //returns True if more work to do
 

--- a/report.h
+++ b/report.h
@@ -92,6 +92,11 @@ void report_counters();
 
 // Prinst voltage of motors
 void report_voltage();
+void calculate_motor_voltage();
+void calculate_force_voltage();
+// Variable for holding voltage value after ADC
+uint16_t analog_voltage_readings[VOLTAGE_SENSOR_COUNT];
+#define FORCE_VALUE_INDEX 4 // Index of analog_voltage_readings that holds force value
 
 // Prints recorded probe position
 void report_probe_parameters(uint8_t error);

--- a/serial.h
+++ b/serial.h
@@ -35,6 +35,9 @@
 
 #define SERIAL_NO_DATA 0xff
 
+volatile uint8_t force_servo_enable;
+volatile uint8_t collect_servo_info;
+
 void serial_init();
 
 void serial_write(uint8_t data);

--- a/settings.c
+++ b/settings.c
@@ -95,6 +95,9 @@ void settings_reset() {
   settings.homing_seek_rate[C_AXIS] = DEFAULT_C_HOMING_SEEK_RATE;
   settings.homing_debounce_delay = DEFAULT_HOMING_DEBOUNCE_DELAY;
   settings.homing_pulloff = DEFAULT_HOMING_PULLOFF;
+  /*****DEBUG VALUE******/
+  //homing_pulloff_Debug = DEFAULT_HOMING_PULLOFF; 
+  /**********************/
   settings.stepper_idle_lock_time = DEFAULT_STEPPER_IDLE_LOCK_TIME;
   settings.max_travel[X_AXIS] = (DEFAULT_X_MAX_TRAVEL);
   settings.max_travel[Y_AXIS] = (DEFAULT_Y_MAX_TRAVEL);

--- a/settings.h
+++ b/settings.h
@@ -26,7 +26,7 @@
 
 
 // define GRBL version and build
-#define GRBL_VERSION "0.9K.3.3"
+#define GRBL_VERSION "0.9K.3.4"
 
 #define GRBL_VERSION_BUILD __DATE__ " " __TIME__
 

--- a/stepper.c
+++ b/stepper.c
@@ -645,6 +645,12 @@ void keyme_init() {
   */
 }
 
+/* This is used to change the Force Sensor Value in the
+   specific PWM register.*/
+void adjustForceSensorPWM(){
+  OCR3BL = settings.force_sensor_level;
+}
+
 /*
 // ISR's for above test code to drive a software PWM
 // Saved for posterity and maybe future use

--- a/stepper.h
+++ b/stepper.h
@@ -47,5 +47,7 @@ void st_update_plan_block_parameters();
 //called periodically to see if we should disable steppers
 void st_check_disable(); 
 
+// Called when using the command to change the force sensitivity level
+void adjustForceSensorPWM();
 
 #endif

--- a/stepper.h
+++ b/stepper.h
@@ -26,6 +26,10 @@
   #define SEGMENT_BUFFER_SIZE 6
 #endif
 
+#define GRIPPER_FORCE_THRESHOLD 5
+
+extern float travel_servo;
+
 // Initialize and setup the stepper motor subsystem
 void stepper_init();
 

--- a/system.c
+++ b/system.c
@@ -181,7 +181,7 @@ uint8_t system_execute_line(char *line)
           if (!read_float(line, &char_counter, &parameter)){
             return(STATUS_BAD_NUMBER_FORMAT);
           }
-          settings.force_sensor_level = parameter;
+          settings.force_sensor_level = (uint8_t)parameter;
           adjustForceSensorPWM();
           break;
         case 'H' : // Perform homing cycle [IDLE/ALARM], only if idle or lost

--- a/system.c
+++ b/system.c
@@ -176,6 +176,14 @@ uint8_t system_execute_line(char *line)
           else { report_ngc_parameters(); }
           break;
 
+        case 'P': // Set force sensitivity parameter. Avoids hastle of changing eeprom settings.
+          char_counter++;
+          if (!read_float(line, &char_counter, &parameter)){
+            return(STATUS_BAD_NUMBER_FORMAT);
+          }
+          settings.force_sensor_level = parameter;
+          adjustForceSensorPWM();
+          break;
         case 'H' : // Perform homing cycle [IDLE/ALARM], only if idle or lost
           if (bit_istrue(settings.flags,BITFLAG_HOMING_ENABLE)) {
             char axis = line[++char_counter];

--- a/system.h
+++ b/system.h
@@ -162,4 +162,16 @@ enum {
 #define TIME_TOGGLE(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PIN|=TIMING_MASK):0)
 
 
+////////////////////////////
+// These values are outputed
+// to the serial port for
+// debugging purposes
+////////////////////////////
+
+/*volatile uint32_t test1Val;
+volatile float    max_travel_Debug;
+volatile float    homing_rate_Debug;
+volatile float    homing_pulloff_Debug;
+*/
+
 #endif

--- a/system.h
+++ b/system.h
@@ -71,6 +71,7 @@
 #define STATE_QUEUED     bit(3) // Indicates buffered blocks, awaiting cycle start.
 #define STATE_CYCLE      bit(4) // Cycle is running
 #define STATE_HOLD       bit(5) // Executing feed hold
+#define STATE_FORCESERVO bit(6) // Force servo process
 
 // Define Grbl alarm codes. Listed most to least serious
 #define ALARM_SOFT_LIMIT  bit(0) // soft limits exceeded
@@ -79,11 +80,13 @@
 #define ALARM_PROBE_FAIL  bit(3) // probe not found
 #define ALARM_HOME_FAIL   bit(4) // home switch transition not found
 #define ALARM_ESTOP       bit(5) // external estop pressed
+#define ALARM_FORCESERVO_FAIL bit(6) // force value not reached while servoing
 
 // Define system flags
 #define SYSFLAG_EOL_REPORT bit(0)  // Block is done executing, report linenum
 #define SYSFLAG_AUTOSTART  bit(1)  // autostart is active
 
+uint16_t force_target_val;
 
 // Define global system variables
 typedef struct {
@@ -135,12 +138,13 @@ void system_execute_startup(char *line);
 // But We don't need such a big value, and we do need the high bit free
 //#define MAX_LINE_NUMBER 9999999
 #define LINENUMBER_EMPTY_BLOCK 0x8000 //the other bit, used as a flag
-#define LINENUMBER_SPECIAL      0x4000
+#define LINENUMBER_SPECIAL      0x4000 //denotes Homing and Probing among a couple other processes
+#define LINENUMBER_SPECIAL_SERVO 0x10000 //denotes force servoing
 #define LINENUMBER_MAX         (LINENUMBER_SPECIAL-1)
 #define LINEMASK_OFF_EDGE         (0x0)
 #define LINEMASK_ON_EDGE         (0x1)
 #define LINEMASK_DONE           (0x2)
-typedef uint16_t linenumber_t;  //resize back to int32 for bigger numbers
+typedef uint32_t linenumber_t;
 
 
 void linenumber_init();
@@ -161,5 +165,8 @@ enum {
 #define TIME_ON(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PORT&=~TIMING_MASK):0)
 #define TIME_TOGGLE(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PIN|=TIMING_MASK):0)
 
-
+// Voltage Monitoring
+#define VOLTAGE_SENSOR_COUNT 5 // number of devices (X,Y,Z,C,F) for which voltage is measured
+// Reasoning for commenting this function is in system.c.
+//void init_ADC();
 #endif


### PR DESCRIPTION
This is a large pull request that moves the force servoing process from python to GRBL. Now the firmware can accept a command followed by a target force value (via serial port) and the gripper motor will move in one motion until that target force value is achieved. This will reduce the time it takes to bump keys significantly and will reduce the messages received by the brain.

EDIT:
Order for Viewing:
- `system.c`: This is where the force servoing command is defined. This finds the command, grabs the
  float directly after (which is the target voltage), and executes the force servoing procedure.
- `motion_control.c`: This is the wrapper function for the force servoing procedure and mimics the
  wrapper function for the homing procedure.
- `limits.c`: This is where the motion is sent to a planning block followed by waking up the motors.
- `stepper.c`: The additions to the stepper motor ISR are for stopping the gripper when the desired
  force value is reached.
- `report.c`: This is where the function for retrieving force and motor voltage values are. Now
  `calculate_force_voltage()` is constantly called in `protocol.c`, while `calculate_motor_voltage` is called only when
  a voltage request is made.
