### PR TITLE
GRBL: increase current to stepper motors while maintaining all other functionality

### DIFF
--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -189,7 +189,8 @@
 #define FVOLT_MASK (1<<FVOLT_BIT)
 
 #define FVOLT_ADC 7  // value to write to ADCSRA to read ADC15
-#define MUX5_BIT 3
+#define MUX5_BIT_POS 3
+#define MUX5_BIT_VALUE 1 // 1 designates ADC 15
 
 // Measurement of Supply Voltage for all motors, MVOLT
 #define MVOLT_DDR DDRF

--- a/report.c
+++ b/report.c
@@ -428,7 +428,7 @@ void calculate_force_voltage(){
   // Set read bit to be the special feedback bit (ADC14)
   // This is bit select 6, plus
   ADMUX = ((1<<REFS0) + (FVOLT_ADC));
-  ADCSRB = (1<<MUX5_BIT);
+  ADCSRB = (MUX5_BIT_VALUE<<MUX5_BIT_POS);
   // Enable capture of ADC
   ADCSRA |= (1<<ADSC);
   // Wait for the result

--- a/report.c
+++ b/report.c
@@ -405,8 +405,13 @@ void calculate_motor_voltage(){
   ADCSRA = (1<<ADEN)|(1<<ADPS2)|(1<<ADPS1)|(1<<ADPS0);
 
   for (i=0;i<(VOLTAGE_SENSOR_COUNT-1); i++){
-    ADCSRB &= ~(1<<MUX5_BIT); // Clear MUX5_BIT which is set when force sensor is target
-    ADMUX = (1<<REFS0) + i; // set next motor target for ADC
+    // If MUX5 bit was set high, it must be cleared
+    // in order for the other analogs to read properly
+    if (MUX5_BIT_VALUE)
+      ADCSRB &= ~(MUX5_BIT_VALUE<<MUX5_BIT_POS);
+
+    // set next motor target for ADC
+    ADMUX = (1<<REFS0) + i;
 
     // Enable capture of ADC
     ADCSRA |= (1<<ADSC);

--- a/stepper.c
+++ b/stepper.c
@@ -625,9 +625,9 @@ void keyme_init() {
 
   // With the comparators and timers set up, use OCR3xL to set compare value
   // In 8 bit mode, only the Low register is needed
-  OCR3AL = 51;  // 1V
+  OCR3AL = 254; // 5V, full current
   OCR3BL = settings.force_sensor_level; // 1.5V default
-  OCR3CL = 153; // 3V
+  OCR3CL = 254; // 5V, full current
 
   /*
   // THIS WAS TEST CODE TO TRY TO DRIVE A SOFTWARE PWM


### PR DESCRIPTION
Increases current to XY and CG axes to maximum while maintaining analog reads properly.  There is some other experimental ADC stuff that was getting in the way because we moved the force sensor to another pin.  This change fixes the current problem but allows for future changes to MUX5_BIT_VALUE for the new force sensor.
