### PR TITLE
Turn on -Wextra/-Werror. Fix resulting errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 # Tune the lines below only if you know what you are doing:
 
 AVRDUDE = avrdude  $(PROGRAMMER) -p $(DEVICE) -B 10 -F -D
-CFLAGS = -Wall -Os -DF_CPU=$(CLOCK) -mmcu=$(DEVICE)
+CFLAGS = -Wall -Werror -Wextra -Os -DF_CPU=$(CLOCK) -mmcu=$(DEVICE)
 COMPILE = avr-gcc $(CFLAGS) -I. -ffunction-sections
 
 # symbolic targets:

--- a/coolant_control.c
+++ b/coolant_control.c
@@ -69,5 +69,7 @@ void coolant_init()
 void coolant_stop()
 {}
 void coolant_run(uint8_t m)
-{}
+{
+    UNUSED(m);
+}
 #endif

--- a/counters.c
+++ b/counters.c
@@ -25,7 +25,7 @@ uint32_t alignment_debounce_timer=0;
 #define PROBE_DEBOUNCE_DELAY_MS 25
 
 
-counters_t counters = {{0}};
+counters_t counters;
 
 // Counters pin initialization routine.
 void counters_init()
@@ -68,7 +68,7 @@ count_t counters_get_count(uint8_t axis)
 }
 
 
-int debounce(uint32_t* bounce_clock, int16_t lockout_ms) {
+int debounce(uint32_t* bounce_clock, uint16_t lockout_ms) {
   uint32_t clock = masterclock;
   //allow another reading if lockout has expired
   if ( (uint32_t)(clock - *bounce_clock) >= lockout_ms ) {
@@ -82,12 +82,12 @@ int debounce(uint32_t* bounce_clock, int16_t lockout_ms) {
 ISR(FDBK_INT_vect) {
   uint8_t state =  FDBK_PIN&FDBK_MASK;
   uint8_t change = (state^counters.state);
-  int8_t dir=0;
 
   // Encoder was removed in rev 4 board
   // Leaving this only as example code for how to read
   // encoder sensors in the future, if we ever add them back
   /*
+  int8_t dir=0;
   //look for encoder change
   if (change & ((1<<Z_ENC_CHA_BIT)|(1<<Z_ENC_CHB_BIT))) { //if a or b changed
     counters.anew = (state>>Z_ENC_CHA_BIT)&1;

--- a/serial.c
+++ b/serial.c
@@ -127,7 +127,7 @@ uint8_t serial_read()
     uint8_t data = rx_buffer[tail];
 
     tail++;
-    if (tail == RX_BUFFER_SIZE) { tail = 0; }
+    if (tail == (uint8_t)RX_BUFFER_SIZE) { tail = 0; }
     rx_buffer_tail = tail;
 
     return data;
@@ -152,7 +152,7 @@ ISR(SERIAL_RX)
     case CMD_RESET:     mc_reset(); break; // Call motion control reset routine.
     default: // Write character to buffer
       next_head = rx_buffer_head + 1;
-      if (next_head == RX_BUFFER_SIZE) { next_head = 0; }
+      if (next_head == (uint8_t)RX_BUFFER_SIZE) { next_head = 0; }
 
       // Write data to buffer unless it is full.
       if (next_head != rx_buffer_tail) {

--- a/spindle_control.c
+++ b/spindle_control.c
@@ -103,5 +103,8 @@ void spindle_init()
 void spindle_stop()
 {}
 void spindle_run(uint8_t d,float r)
-{}
+{
+    UNUSED(d);
+    UNUSED(r);
+}
 #endif

--- a/system.h
+++ b/system.h
@@ -161,12 +161,17 @@ enum {
 };
 
 #define ACTIVE_TIMER time_STEP_ISR
-#define TIME_OFF(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PORT|=TIMING_MASK):0)
-#define TIME_ON(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PORT&=~TIMING_MASK):0)
-#define TIME_TOGGLE(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PIN|=TIMING_MASK):0)
+#define TIME_OFF(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PORT|=TIMING_MASK):(void)tid)
+#define TIME_ON(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PORT&=~TIMING_MASK):(void)tid)
+#define TIME_TOGGLE(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PIN|=TIMING_MASK):(void)tid)
 
 // Voltage Monitoring
 #define VOLTAGE_SENSOR_COUNT 5 // number of devices (X,Y,Z,C,F) for which voltage is measured
 // Reasoning for commenting this function is in system.c.
 //void init_ADC();
+
+// Helper for squelching 'unused parameter' errors
+#define UNUSED(param) (void)(param);
+
+
 #endif


### PR DESCRIPTION
There were a couple of existing warnings in the code with the current build settings.  Ratcheting up the warning level unmasked a few more minor issues that shouldn't have any effect on the runtime behavior.

Figured now is a good time to do this as we're going to be hacking on grbl with increasing frequency.
