### PR TITLE
Add carousel magazine missing alarm/stop.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DEVICE     ?= atmega2560
 CLOCK      = 16000000
 PROGRAMMER ?= -c avrisp2 -P /dev/ttyUSB0 -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
-             protocol.o stepper.o eeprom.o settings.o planner.o nuts_bolts.o limits.o \
+             protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
              print.o probe.o report.o system.o counters.o
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m

--- a/config.h
+++ b/config.h
@@ -33,6 +33,9 @@
 #define DEFAULTS_KEYME_FM
 //#define DEFAULTS_BENCH
 
+// Check the gap between magazines and activate alarm if magazine is missing
+#define MAG_GAP_CHECK_ENABLE 1
+
 // Serial baud rate
 #define BAUD_RATE 38400
 

--- a/counters.c
+++ b/counters.c
@@ -108,7 +108,7 @@ ISR(FDBK_INT_vect) {
   //count conveyor axis alignment pulses.
   if (change & (1<<ALIGN_SENSE_BIT)) { //sensor changed
     if (debounce(&alignment_debounce_timer, PROBE_DEBOUNCE_DELAY_MS)){
-      if (!(state&PROBE_MASK)) { //low is on.
+      if (!(state & MAGAZINE_ALIGNMENT_MASK)) { //low is on.
         counters.counts[C_AXIS]++;
       }
     }

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -112,11 +112,17 @@
 #define PINOUT_MASK ((1<<PIN_RESET)|(1<<PIN_FEED_HOLD)|(1<<PIN_CYCLE_START))
 
 // Define probe switch input pin.
-#define PROBE_DDR       DDRK
-#define PROBE_PIN       PINK
-#define PROBE_PORT      PORTK
-#define PROBE_BIT       3   // Atmega2560 pin 86 // Arduino Analog Pin 11
-#define PROBE_MASK      (1<<PROBE_BIT)
+#define MAGAZINE_ALIGNMENT_DDR       DDRK
+#define MAGAZINE_ALIGNMENT_PIN       PINK
+#define MAGAZINE_ALIGNMENT_PORT      PORTK
+#define MAGAZINE_ALIGNMENT_BIT       3   // Atmega2560 pin 86 // Arduino Analog Pin 11
+#define MAGAZINE_ALIGNMENT_MASK      (1 << MAGAZINE_ALIGNMENT_BIT)
+
+//Alias existing probe masks in default Grbl
+#define PROBE_DDR       MAGAZINE_ALIGNMENT_DDR
+#define PROBE_PIN       MAGAZINE_ALIGNMENT_PIN
+#define PROBE_PORT      MAGAZINE_ALIGNMENT_PORT
+#define PROBE_MASK      MAGAZINE_ALIGNMENT_MASK
 
 // Start of PWM & Stepper Enabled Spindle
 #ifdef VARIABLE_SPINDLE

--- a/defaults.h
+++ b/defaults.h
@@ -109,6 +109,7 @@
   #define DEFAULT_DECAY_MODE 0         //slowest
   #define DEFAULT_COUNTS_PER_IDX 4000  //counts per encoder rev
   #define DEFAULT_FORCE_SENSOR_LEVEL 77 // 1.5V out of 5.0V=255 max
+  #define DEFAULT_MAG_GAP_LIMIT 12.5 //in mm (units)
 #endif
 
 #ifdef DEFAULTS_BENCH

--- a/limits.h
+++ b/limits.h
@@ -35,6 +35,7 @@ typedef struct {
   uint8_t active;
   volatile uint8_t ishoming;
   volatile uint8_t isservoing;
+  uint8_t mag_gap_check; //keyme specific
 } limit_t;
 
 extern limit_t limits;

--- a/magazine.c
+++ b/magazine.c
@@ -1,0 +1,51 @@
+/*
+  Not part of Grbl. Written by KeyMe.
+*/
+
+#include "system.h"
+#include "settings.h"
+#include "magazine.h"
+#include "limits.h"
+#include "protocol.h"
+#include "stepper.h"
+
+void magazine_init()
+{
+  MAGAZINE_ALIGNMENT_DDR &= ~(MAGAZINE_ALIGNMENT_MASK); // Configure as input pin
+  MAGAZINE_ALIGNMENT_PORT |= MAGAZINE_ALIGNMENT_MASK; // Enable internal pull-up resistors. Normal high operation
+  memcpy(sys.probe_position, sys.position, sizeof(int32_t) * N_AXIS); // Set the magazine alignment position to the current position
+}
+
+//KeyMe function
+// Monitors the gap in units between mags and throws an alarm if the gap is larger than a
+// specified threshold.
+void magazine_gap_monitor()
+{
+  const uint8_t magazine_alignment_on = magazine_get_state();
+  // When the probe is detected, copy the current position of all axes
+  // into sys.probe_position
+  if(magazine_alignment_on){
+    memcpy(sys.probe_position, sys.position, sizeof(int32_t) * N_AXIS);
+  }
+
+  if(limits.mag_gap_check == 0)
+    return;
+  // Activate alarm if the gap between the current position and the previous
+  // probe position becomes too large. Only do this when the system has already homed
+  const int32_t cur_pos = sys.position[C_AXIS];
+  const int32_t probe_pos = sys.probe_position[C_AXIS];
+  const int32_t delta_pos_mm = abs(cur_pos - probe_pos) / settings.steps_per_mm[C_AXIS];
+  if(delta_pos_mm > settings.mag_gap_limit){
+    sys.state = STATE_ALARM;
+    sys.alarm |= ALARM_MAG_MISSING;
+    SYS_EXEC |= (EXEC_FEED_HOLD | EXEC_ALARM | EXEC_CRIT_EVENT);
+    st_go_idle();
+    protocol_execute_runtime();
+    
+  }
+  return;
+
+}
+
+
+

--- a/magazine.h
+++ b/magazine.h
@@ -1,0 +1,17 @@
+/*
+  Not part of Grbl. Written by KeyMe.
+*/
+
+#ifndef magazine_h
+#define magazine_h
+
+// Magazine allignment pin initialization routine
+void magazine_init();
+
+#define magazine_get_state() (!(MAGAZINE_ALIGNMENT_PIN & MAGAZINE_ALIGNMENT_MASK))
+
+// Monitors the gap in units between mags and throws an alarm if the gap is larger than a
+// specified threshold.
+void magazine_gap_monitor();
+
+#endif

--- a/main.c
+++ b/main.c
@@ -31,6 +31,7 @@
 #include "motion_control.h"
 #include "limits.h"
 #include "probe.h"
+#include "magazine.h"
 #include "report.h"
 #include "counters.h"
 
@@ -82,6 +83,7 @@ int main(void)
     coolant_init();
     limits_init();
     probe_init();
+    magazine_init();
     plan_reset(); // Clear block buffer and planner variables
     st_reset(); // Clear stepper subsystem variables.
 

--- a/motion_control.c
+++ b/motion_control.c
@@ -49,7 +49,7 @@ void mc_line(float *target, float feed_rate, uint8_t invert_feed_rate, linenumbe
   // If enabled, check for soft limit violations. Placed here all line motions are picked up
   // from everywhere in Grbl.
   if (bit_istrue(settings.flags,BITFLAG_SOFT_LIMIT_ENABLE)) { limits_soft_check(target); }    
-  
+
   // If in check gcode mode, prevent motion by blocking planner. Soft limits still work.
   if (sys.state == STATE_CHECK_MODE) { return; }
   

--- a/probe.c
+++ b/probe.c
@@ -22,15 +22,13 @@
 #include "probe.h"
 #include "counters.h"
 
-
-
 // Probe pin initialization routine.
 void probe_init() 
 {
   PROBE_DDR &= ~(PROBE_MASK); // Configure as input pins
   PROBE_PORT |= PROBE_MASK;   // Enable internal pull-up resistors. Normal high operation.
-}
 
+}
 
 // Monitors probe pin state and records the system position when detected. Called by the
 // stepper ISR per ISR tick.

--- a/probe.h
+++ b/probe.h
@@ -25,12 +25,12 @@
 #define PROBE_OFF     0 // No probing. (Must be zero.)
 #define PROBE_ACTIVE  1 // Actively watching the input pin.
 
-
 // Probe pin initialization routine.
 void probe_init();
 
 // Returns probe pin state. Triggered = true. Called by gcode parser and probe state monitor.
 #define probe_get_state() (!(PROBE_PIN & PROBE_MASK))
+
 
 // Monitors probe pin state and records the system position when detected. Called by the
 // stepper ISR per ISR tick.

--- a/settings.c
+++ b/settings.c
@@ -103,6 +103,7 @@ void settings_reset() {
   settings.microsteps = DEFAULT_MICROSTEPPING;
   settings.decay_mode = DEFAULT_DECAY_MODE;
   settings.force_sensor_level = DEFAULT_FORCE_SENSOR_LEVEL;
+  settings.mag_gap_limit = DEFAULT_MAG_GAP_LIMIT;
   write_global_settings();
 }
 

--- a/settings.h
+++ b/settings.h
@@ -84,6 +84,7 @@ typedef struct {
   uint8_t microsteps; //2 bits per motor
   uint8_t decay_mode; //0..3  slow-->fast
   uint8_t force_sensor_level; //0..255  low-->high sensitivity
+  uint8_t mag_gap_limit;
 //  uint8_t status_report_mask; // Mask to indicate desired report data.
 } settings_t;
 extern settings_t settings;

--- a/stepper.c
+++ b/stepper.c
@@ -28,6 +28,7 @@
 #include "limits.h"
 #include "motion_control.h"
 #include "report.h"
+#include "magazine.h"
 
 // Some useful constants.
 #define DT_SEGMENT (1.0/(ACCELERATION_TICKS_PER_SECOND*60.0)) // min/segment
@@ -196,7 +197,6 @@ void st_disable(uint8_t disable, uint8_t mask) {
   if (disable) { STEPPERS_DISABLE_PORT |= (STEPPERS_DISABLE_MASK&mask); }
   else { STEPPERS_DISABLE_PORT &= ~(STEPPERS_DISABLE_MASK&mask); }
 }
-
 
 // Stepper state initialization. Cycle should only start if the st.cycle_start flag is
 // enabled. Startup init and limits call this function but shouldn't start the cycle.
@@ -389,10 +389,11 @@ ISR(TIMER4_COMPA_vect)
       return; // Nothing to do but exit.
     }
   }
-
-
   // Check probing state.
   probe_state_monitor();
+
+  // Check if mag is missing on the carousel
+  magazine_gap_monitor();
 
   // Reset step out bits.
   st.step_outbits = 0;

--- a/system.c
+++ b/system.c
@@ -235,7 +235,6 @@ uint8_t system_execute_line(char *line)
       plan_sync_position(); // Sync planner position to current machine position for pull-off move.
       sys.state = STATE_IDLE;
       break;
-
       /* END KEYME SPECIFIC */
 
 //  case 'J' : break;  // Jogging methods

--- a/system.h
+++ b/system.h
@@ -81,6 +81,7 @@
 #define ALARM_HOME_FAIL   bit(4) // home switch transition not found
 #define ALARM_ESTOP       bit(5) // external estop pressed
 #define ALARM_FORCESERVO_FAIL bit(6) // force value not reached while servoing
+#define ALARM_MAG_MISSING  bit(7) //Mag expected but not sensed
 
 // Define system flags
 #define SYSFLAG_EOL_REPORT bit(0)  // Block is done executing, report linenum


### PR DESCRIPTION
These changes cause the carousel to stop when a magazine is missing. It uses the probe sensor. The name of the probe sensor is changed to magazine alignment sensor. However, all probe functionality of the original Grbl is kept.

The alarm can be cleared in a similar fashion to other alarms and the motors are de-energized when the alarm is issued, similar to other alarms.

The alarm is issued whenever the carousel moves and a magazine is missing, including when the carousel is homing.
