### PR TITLE
Move checksum to after newline

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -84,15 +84,12 @@ void serial_sendchar(uint8_t data) {
 }
 
 void serial_write(uint8_t data) {
+  checksum+=data;
+  serial_sendchar(data);
   if (data == '\n') {
     serial_sendchar(checksum);
     checksum = 0;
   }
-  else {
-    checksum+=data;
-  }
-  serial_sendchar(data);
-
 }
 
 


### PR DESCRIPTION
This removes the possiblity of accidentally truncating a line if the
message checksum == 0xA (newline).  The inadvertant truncation can lead
to checksum errors and lost messages.

(Includes requisite changes to grblcon)
