### PR TITLE
Rearchitect grbl to accept large gcode programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,11 @@
 
 DEVICE     ?= atmega2560
 CLOCK      = 16000000
-PROGRAMMER ?= -c avrisp2 -P /dev/ttyUSB0 -v -v
+PORT       ?= /dev/ttyUSB0
+PROGRAMMER ?= -c wiring -P $(PORT) -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
-             print.o probe.o report.o system.o counters.o
+             print.o probe.o report.o system.o counters.o gqueue.o progman.o
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 # update that line with this when programmer is back up:

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -12,7 +12,7 @@
 #define RX_BUFFER_SIZE		255
 #define TX_BUFFER_SIZE		128
 #define BLOCK_BUFFER_SIZE	48
-#define LINE_BUFFER_SIZE	100
+#define LINE_BUFFER_SIZE	255
 
 // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
 #define STEP_DDR      DDRH

--- a/gqueue.c
+++ b/gqueue.c
@@ -1,0 +1,34 @@
+#include <gqueue.h>
+
+void queue_enqueue(volatile void *q, const void *elt)
+{
+  volatile struct generic_queue *gq = q;
+  if (gq->len == 0) {
+    gq->head = gq->memory;
+    gq->tail = gq->memory;
+  } else {
+    if (gq->tail == gq->memory + (gq->max_capacity - 1) * gq->item_size) {
+      gq->tail = gq->memory;
+    } else {
+      gq->tail = (uint8_t *)gq->tail + gq->item_size;
+    }
+  }
+
+  memcpy((void*)gq->tail, elt, gq->item_size);
+  gq->len++;
+}
+
+void queue_dequeue(volatile void *q, void *elt)
+{
+  volatile struct generic_queue *gq = q;
+  memcpy(elt, (void*)gq->head, gq->item_size);
+
+  if (gq->head == gq->memory + (gq->max_capacity - 1) * gq->item_size) {
+    gq->head = gq->memory;
+  } else {
+    if (gq->len > 1) {
+      gq->head = (uint8_t *)gq->head + gq->item_size;
+    }
+  }
+  gq->len--;
+}

--- a/gqueue.h
+++ b/gqueue.h
@@ -1,0 +1,54 @@
+#ifndef _QUEUE_H_
+#define _QUEUE_H_
+
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct generic_queue {
+  volatile void *head;
+  volatile void *tail;
+  int32_t item_size;
+  int32_t len;
+  int32_t max_capacity;
+  volatile uint8_t memory[0];
+};
+
+#define DECLARE_QUEUE(name, element_type, max_size)	\
+  static struct {					\
+    struct generic_queue gq;				\
+    element_type __elements[max_size];			\
+  } name;
+
+
+static inline void queue_init(volatile void *q, int elt_size, int capacity)
+{
+  volatile struct generic_queue *gq = q;
+  const size_t q_size = (sizeof(struct generic_queue) +
+			 (elt_size * capacity));
+  memset((void*)q, 0x00, q_size);
+  gq->item_size = elt_size;
+  gq->max_capacity = capacity;
+}
+
+static inline bool queue_is_empty(volatile void *q)
+{
+  volatile struct generic_queue *gq = q;
+
+  return (gq->len == 0);
+}
+static inline int queue_get_len(volatile void *q)
+{
+  volatile struct generic_queue *gq = q;
+  return gq->len;
+}
+static inline bool queue_is_full(volatile void *q)
+{
+  volatile struct generic_queue *gq = q;
+  return (gq->len >= gq->max_capacity);
+}
+void queue_enqueue(volatile void *q, const void *elt) __attribute__((nonnull));
+void queue_dequeue(volatile void *q, void *elt) __attribute__((nonnull));
+
+#endif

--- a/main.c
+++ b/main.c
@@ -34,6 +34,7 @@
 #include "magazine.h"
 #include "report.h"
 #include "counters.h"
+#include "progman.h"
 
 
 // Declare system global variable structure
@@ -86,6 +87,7 @@ int main(void)
     magazine_init();
     plan_reset(); // Clear block buffer and planner variables
     st_reset(); // Clear stepper subsystem variables.
+    progman_init();
 
     // Sync cleared gcode and planner positions to current system position.
     plan_sync_position();

--- a/motion_control.c
+++ b/motion_control.c
@@ -196,7 +196,7 @@ void mc_arc(float *position, float *target, float *offset, float radius, float f
 // Execute dwell in seconds.
 void mc_dwell(float seconds) 
 {
-  report_status_message(STATUS_OK); //report that we are dwelling
+  /* TODO: Report a dwell status? -JC */
   if (sys.state == STATE_CHECK_MODE) { return; }
    
   uint16_t i = floor(1000/DWELL_TIME_STEP*seconds);
@@ -287,7 +287,7 @@ void mc_probe_cycle(float *target, float feed_rate, uint8_t invert_feed_rate, li
   protocol_buffer_synchronize(); // Finish all queued commands
   if (sys.abort) { return; } // Return if system reset has been issued.
 
-  report_status_message(STATUS_OK); //report that we are probing
+  /* TODO: Report a probing status? -JC */
 
   // Perform probing cycle. Planner buffer should be empty at this point.
   mc_line(target, feed_rate, invert_feed_rate, line_number);

--- a/progman.c
+++ b/progman.c
@@ -1,0 +1,212 @@
+#include "gqueue.h"
+
+#include "system.h"
+#include "report.h"
+#include "serial.h"
+#include "motion_control.h"
+
+#define PROGRAM_MAX_SIZE (1024 * 3)
+
+DECLARE_QUEUE(prog_buf, uint8_t, PROGRAM_MAX_SIZE);
+
+enum progman_state {
+  E_PROGMAN_CONSUMING = 0,
+  E_PROGMAN_COMMENT
+};
+
+static struct {
+  uint8_t line_assy[LINE_BUFFER_SIZE];
+  uint8_t line_pos;
+  bool in_comment;
+  enum progman_state state;
+} progman;
+
+void progman_init(void)
+{
+  progman.line_pos = 0;
+
+  queue_init(&prog_buf, sizeof(uint8_t), PROGRAM_MAX_SIZE);
+
+  while (!queue_is_empty(&prog_buf)) {
+    uint8_t nil;
+    queue_dequeue(&prog_buf, &nil);
+  }
+  progman.state = E_PROGMAN_CONSUMING;
+}
+
+bool progman_handle_runtime_cmd(char data)
+{
+  switch (data) {
+  case CMD_COUNTER_REPORT:
+    request_report(REQUEST_COUNTER_REPORT,0);
+    break;
+  case CMD_VOLTAGE_REPORT:
+    request_report(REQUEST_VOLTAGE_REPORT,0);
+    break;
+  case CMD_STATUS_REPORT:
+    request_report(REQUEST_STATUS_REPORT,0);
+    break;
+  case CMD_LIMIT_REPORT:
+    request_report(REQUEST_LIMIT_REPORT,0);
+    break;
+  case CMD_CYCLE_START:
+    /* Set as true */
+    SYS_EXEC |= EXEC_CYCLE_START;
+    break;
+  case CMD_FEED_HOLD:
+    /* Set as true */
+    SYS_EXEC |= EXEC_FEED_HOLD;
+    break;
+  case CMD_RESET:
+    /* Call motion control reset routine. */
+    mc_reset();
+    break;
+  case '\n':			/* Intentional fall through */
+  case '\r':
+    /* If we got a bare newline character out of context, it's likely
+       due to the fact that our previous character was consumed as
+       a runtime command, so we should just swallow it */
+    if ((progman.line_pos < 1) &&
+	(E_PROGMAN_CONSUMING == progman.state)) {
+      report_status_message(STATUS_OK);
+      break;
+    }
+  default:
+    /* If we didn't handle the command, return false  */
+    return false;
+  }
+
+  return true;
+}
+
+static bool progman_consume_byte(char data)
+{
+
+  /* Immediately try to toss out any comments */
+  switch (data) {
+  case '(':
+    progman.state = E_PROGMAN_COMMENT;
+    break;
+  case ')':
+    if (E_PROGMAN_COMMENT == progman.state) {
+      progman.state = E_PROGMAN_CONSUMING;
+    } else {
+      report_status_message(STATUS_INVALID_STATEMENT);
+    }
+    break;
+  }
+
+  if (E_PROGMAN_COMMENT == progman.state) {
+    return false;
+  }
+
+  /* Discard whitespace and control characters to maximize space
+     efficiency */
+  switch(data) {
+  case ' ':
+  case '/':
+    /* TODO: Figure out how to handle block delete -JC */
+    return false;
+  }
+
+  /* Store the data */
+  progman.line_assy[progman.line_pos++] = data;
+
+  /* If we're at the end of a line, return true so that the line will
+     be validated */
+  switch(data) {
+  case '\r':
+  case '\n':
+    return true;
+  }
+
+  return false;
+}
+
+bool progman_validate_gcode_line(void)
+{
+  /* Filters out any line that contains non printable characters */
+  int i;
+  for (i = 0; i < progman.line_pos; i++) {
+    /* Pass on whitespace */
+    switch (progman.line_assy[i]) {
+    case '\r':
+    case '\n':
+      continue;
+    default:
+      if (progman.line_assy[i] < ' ' || progman.line_assy[i] > '~') {
+	return false;
+      }
+    }
+  }
+  return true;
+}
+
+static bool progman_buffer_gcode_line(void)
+{
+  /* Moves the currently assembled gcode line into the program buffer */
+  int i;
+  bool result = true;
+  for (i = 0; i < progman.line_pos; i++) {
+    if (queue_is_full(&prog_buf)) {
+      result = false;
+      goto cleanup_and_exit;
+    }
+    queue_enqueue(&prog_buf, &progman.line_assy[i]);
+  }
+
+cleanup_and_exit:
+  progman.line_pos = 0;
+  return result;
+}
+
+bool progman_read(uint8_t *dst)
+{
+  /* Attempts to move a single byte into *dst. Returns true for
+     success, or false if the queue is empty */
+
+  if (queue_is_empty(&prog_buf)) {
+    return false;
+  }
+
+  queue_dequeue(&prog_buf, dst);
+  return true;
+}
+
+void progman_execute(void)
+{
+  /* Just loop around if our buffer is full */
+  if (queue_is_full(&prog_buf)) {
+    return;
+  }
+
+  uint8_t c = serial_read();
+
+  if (c == SERIAL_NO_DATA) {
+    return;
+  }
+
+  /* Runtime commands are a special case, we short circuit putting
+     them in the buffer and perform the specified action
+     immediately */
+  if (progman_handle_runtime_cmd(c)) {
+    return;
+  }
+
+  /* Try to consume the byte (ignoring comments).  A successful
+     return means we've consumed an entire line and should attempt to
+     validate it. */
+  if (progman_consume_byte(c)) {
+    if (!progman_validate_gcode_line()) {
+      report_status_message(STATUS_INVALID_STATEMENT);
+      progman.line_pos = 0;
+      return;
+    }
+
+    if (!progman_buffer_gcode_line()) {
+      report_status_message(STATUS_OVERFLOW);
+      return;
+    }
+    report_status_message(STATUS_OK);
+  }
+}

--- a/progman.h
+++ b/progman.h
@@ -1,0 +1,10 @@
+#ifndef _PROGMAN_H_
+#define _PROGMAN_H_
+
+#include <stdint.h>
+
+void progman_init(void);
+void progman_execute(void);
+bool progman_read(uint8_t *dst);
+
+#endif	/* _PROGMAN_H_ */

--- a/serial.c
+++ b/serial.c
@@ -139,26 +139,16 @@ ISR(SERIAL_RX)
 
   // Pick off runtime command characters directly from the serial stream. These characters are
   // not passed into the buffer, but these set system state flag bits for runtime execution.
-  switch (data) {
-    case CMD_COUNTER_REPORT: request_report(REQUEST_COUNTER_REPORT,0); break;
-    case CMD_VOLTAGE_REPORT: request_report(REQUEST_VOLTAGE_REPORT,0); break;
-    case CMD_STATUS_REPORT: request_report(REQUEST_STATUS_REPORT,0); break;
-    case CMD_LIMIT_REPORT: request_report(REQUEST_LIMIT_REPORT,0); break;
-    case CMD_CYCLE_START: SYS_EXEC |= EXEC_CYCLE_START; break; // Set as true
-    case CMD_FEED_HOLD:  SYS_EXEC |= EXEC_FEED_HOLD; break; // Set as true
-    case CMD_RESET:     mc_reset(); break; // Call motion control reset routine.
-    default: // Write character to buffer
-      next_head = rx_buffer_head + 1;
-      if (next_head == RX_BUFFER_SIZE) { next_head = 0; }
+  next_head = rx_buffer_head + 1;
+  if (next_head == (uint8_t)RX_BUFFER_SIZE) { next_head = 0; }
 
-      // Write data to buffer unless it is full.
-      if (next_head != rx_buffer_tail) {
-        rx_buffer[rx_buffer_head] = data;
-        rx_buffer_head = next_head;
+  // Write data to buffer unless it is full.
+  if (next_head != rx_buffer_tail) {
+	  rx_buffer[rx_buffer_head] = data;
+	  rx_buffer_head = next_head;
 
-      }
-      //TODO: else alarm on overflow?
   }
+  //TODO: else alarm on overflow?
 }
 
 

--- a/system.c
+++ b/system.c
@@ -154,7 +154,10 @@ void system_execute_startup(char *line)
     } else {
       if (line[0] != 0) {
         printString(line); // Echo startup line to indicate execution.
-        report_status_message(gc_execute_line(line));
+	uint8_t status = gc_execute_line(line);
+	if (status) {
+	  report_status_message(status);
+	}
       }
     }
   }
@@ -282,7 +285,6 @@ uint8_t system_execute_line(char *line)
               if (axis == N_AXIS) { return(STATUS_INVALID_STATEMENT); }
               axis = (1<<axis);  //convert idx to mask
             }
-            report_status_message(STATUS_OK); //report that we are homing
             mc_homing_cycle(axis);
             if (!sys.abort) { system_execute_startup(line); } // Execute startup scripts after successful homing.
             return STATUS_QUIET_OK; //already said ok
@@ -293,7 +295,6 @@ uint8_t system_execute_line(char *line)
           read_float(line, &char_counter, &value);
           // This is the force value the gripper motor will approach. Specified by kiosk.
           force_target_val = (uint16_t)value;
-          report_status_message(STATUS_OK);
           mc_force_servo_cycle();
           if (!sys.abort) { system_execute_startup(line);}
           return STATUS_QUIET_OK;


### PR DESCRIPTION
This is a pretty significant change to the overall behavior and includes
the following major changes:
- The addition of the 'program manager', which pre-screens, compresses,
  and buffers entire gcode programs (up to 3k bytes).  This also
  includes the handling of 'system' commands, such as reading the
  ADCs (which means we no longer do any sort of work in the ISR).
- Re-organizing protocol.c to read pre-tidied lines from the program
  manager (this means simpler logic in the line assembly code)
- Adding a program manager execution step in the protocol runtime (Which
  allows for the program manager to process the serial buffer even when
  the line buffer is full and we're not actively parsing GRBL lines)
- Removing positive confirmations from G-Code execution.  An 'ok'
  response simply means that we received a line containing printable
  characters.  The successful execution of these lines won't actually
  cause 'ok' responses to stream back, meaning that the only thing we
  should pipe up about is something breaking.
- Minor updates to grblcon to allow for uploading gcode files

This should allow for a clean break between upload and execute as described in: https://github.com/keyme/kiosk/issues/8040
