### PR TITLE
Add ability for multiple axes to home simultaneously

### DIFF
--- a/config.h
+++ b/config.h
@@ -79,12 +79,13 @@
 // on separate pin, but homed in one cycle. Also, it should be noted that the function of hard limits
 // will not be affected by pin sharing.
 // NOTE: CYCLE is set for the keyme machine.  Gripper open first. Then Y, then X & Carousel
-#define HOMING_CYCLE_0 (1<<X_AXIS)                // REQUIRED: First move X
-#define HOMING_CYCLE_1 (1<<Y_AXIS)                // Clear Y Axis
-#define HOMING_CYCLE_2 ((1<<Z_AXIS)|(1<<C_AXIS))  // Z and carousel ok at same time.
+#define HOMING_CYCLE_0 (1 << X_AXIS)   // REQUIRED: First move X
+#define HOMING_CYCLE_1 (1 << Y_AXIS)   
+#define HOMING_CYCLE_2 (1 << Z_AXIS)   // Gripper
+#define HOMING_CYCLE_3 (1 << C_AXIS)
 
 
-#define HOMING_CYCLE_ALL  (HOMING_CYCLE_0|HOMING_CYCLE_1|HOMING_CYCLE_2)
+#define HOMING_CYCLE_ALL  (HOMING_CYCLE_0 | HOMING_CYCLE_1 | HOMING_CYCLE_2 | HOMING_CYCLE_3)
 // Number of homing cycles performed after when the machine initially jogs to limit switches.
 // This help in preventing overshoot and should improve repeatability. This value should be one or
 // greater.

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -9,10 +9,10 @@
 #define SERIAL_UDRE USART0_UDRE_vect
 
 // Increase Buffers to make use of extra SRAM
-#define RX_BUFFER_SIZE		256
-#define TX_BUFFER_SIZE		128
-#define BLOCK_BUFFER_SIZE	48
-#define LINE_BUFFER_SIZE	100
+#define RX_BUFFER_SIZE          256
+#define TX_BUFFER_SIZE          128
+#define BLOCK_BUFFER_SIZE       48
+#define LINE_BUFFER_SIZE        100
 
 // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
 #define STEP_DDR      DDRH

--- a/limits.c
+++ b/limits.c
@@ -77,6 +77,7 @@ void limits_enable(uint8_t axes, uint8_t expected) {
   limits.expected = bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS)?~expected:expected;
   limits.active = axes<<LIMIT_BIT_SHIFT;
   limits.mag_gap_check = MAG_GAP_CHECK_ENABLE;
+  memcpy(sys.probe_position, sys.position, sizeof(float) * N_AXIS);
 }
 
 
@@ -118,7 +119,7 @@ void limits_go_home(uint8_t cycle_mask)
   // Initialize homing in search mode to quickly engage the specified cycle_mask limit switches.
   uint8_t approach = ~0;  //approach has all bits set (negative dir) or none (positive)
   uint8_t idx;
-  uint8_t n_cycle = (2*N_HOMING_LOCATE_CYCLE);
+  uint8_t n_cycle = (2 * N_HOMING_LOCATE_CYCLE);
   float target[N_AXIS];
 
   uint8_t flipped = settings.homing_dir_mask>>X_DIRECTION_BIT;  //assumes keyme configuration.
@@ -170,7 +171,7 @@ void limits_go_home(uint8_t cycle_mask)
 
     // axislock bit is high if axis is homing, so we only enable checking on moving axes.
     limits_enable(axislock,~approach);  //expect 0 on approach (stop when 1). vice versa for pulloff
-    limits.ishoming = 1;
+    limits.ishoming = axislock << LIMIT_BIT_SHIFT;
 
     st_prep_buffer(); // Prep and fill segment buffer from newly planned block.
     st_wake_up(); // Initiate motion

--- a/magazine.c
+++ b/magazine.c
@@ -30,6 +30,7 @@ void magazine_gap_monitor()
 
   if(limits.mag_gap_check == 0)
     return;
+
   // Activate alarm if the gap between the current position and the previous
   // probe position becomes too large. Only do this when the system has already homed
   const int32_t cur_pos = sys.position[C_AXIS];

--- a/motion_control.c
+++ b/motion_control.c
@@ -224,16 +224,8 @@ void mc_homing_cycle(uint8_t axis_mask)
   // -------------------------------------------------------------------------------------
   // Perform homing routine. NOTE: Special motion case. Only system reset works.
   
-  // If all axes are selected, home the axes sequentially
-  if (axis_mask == HOMING_CYCLE_ALL) {
-    limits_go_home((HOMING_CYCLE_0) & axis_mask); 
-    limits_go_home((HOMING_CYCLE_1) & axis_mask);  
-    limits_go_home((HOMING_CYCLE_2) & axis_mask); 
-    limits_go_home((HOMING_CYCLE_3) & axis_mask);   
-  } else {
-    limits_go_home(axis_mask);
-  }
-    
+  limits_go_home(axis_mask);
+      
   protocol_execute_runtime(); // Check for reset and set system abort.
   if (sys.abort) { return; } // Did not complete. Alarm state set by mc_alarm.
 

--- a/motion_control.c
+++ b/motion_control.c
@@ -224,16 +224,15 @@ void mc_homing_cycle(uint8_t axis_mask)
   // -------------------------------------------------------------------------------------
   // Perform homing routine. NOTE: Special motion case. Only system reset works.
   
-  // Search to engage all axes limit switches at faster homing seek rate.
-  limits_go_home(HOMING_CYCLE_0&axis_mask);  // Homing cycle 0
-  #ifdef HOMING_CYCLE_1
-    limits_go_home(HOMING_CYCLE_1&axis_mask);  // Homing cycle 1
-  #endif
-  #ifdef HOMING_CYCLE_2
-    limits_go_home(HOMING_CYCLE_2&axis_mask);  // Homing cycle 2
-  #endif
-
-
+  // If all axes are selected, home the axes sequentially
+  if (axis_mask == HOMING_CYCLE_ALL) {
+    limits_go_home((HOMING_CYCLE_0) & axis_mask); 
+    limits_go_home((HOMING_CYCLE_1) & axis_mask);  
+    limits_go_home((HOMING_CYCLE_2) & axis_mask); 
+    limits_go_home((HOMING_CYCLE_3) & axis_mask);   
+  } else {
+    limits_go_home(axis_mask);
+  }
     
   protocol_execute_runtime(); // Check for reset and set system abort.
   if (sys.abort) { return; } // Did not complete. Alarm state set by mc_alarm.

--- a/stepper.c
+++ b/stepper.c
@@ -263,7 +263,46 @@ void st_check_disable() {
   }
 }
 
+//Called from ISR(TIMER4_COMPA_vect) - needs to be very efficient 
+void st_limit_check(){
+  // While homing or if hard limits enabled
 
+  // Limit checking performed here
+
+  // LIMIT_PIN - Input buffer of port to which home sensors are connected
+  // limits.expected - approach set in limits.c. limits.expected stores what the pins in LIMIT_PIN
+  // should be when the axes are moving and have not reached the home sensor
+  // limits.active - active bit is set in limits.active if axis is homing
+  // If home sensor is reached in LIMIT_PIN and the pin is different than
+  // that of limits.expected and the axis is homing as set in limits.active,
+  // then set the bit for that pin in must_stop, to indicate that the corresponding
+  // axis should stop
+
+  //Disable magazine gap checking if carousel has finished homing, but other axes are still homing
+  if( !(limits.ishoming & (1 << C_AXIS)) && limits.ishoming){
+    limits.mag_gap_check = 0 ;
+  }
+  
+  uint8_t must_stop = (( (LIMIT_PIN) ^ limits.expected) & limits.active);
+  if (must_stop) {
+    st.step_outbits &= ~(must_stop >> LIMIT_BIT_SHIFT);
+    limits.ishoming &= ~(must_stop >> LIMIT_BIT_SHIFT); // If an axis is done homing, clear the corresponding bit in limits.ishoming
+     
+   if (!limits.ishoming) {
+      request_report(REQUEST_STATUS_REPORT|REQUEST_LIMIT_REPORT,LINENUMBER_EMPTY_BLOCK);
+    }
+    //if limits made but not homing , servoing, or alarmed already: critical alarm.
+    if ( !(sys.state & (STATE_ALARM|STATE_HOMING)) && !(sys.state & (STATE_ALARM|STATE_FORCESERVO)) &&
+         bit_isfalse(SYS_EXEC,EXEC_ALARM)) {
+      mc_reset(); // Initiate system kill.
+      // Indicate hard limit critical event, print limits
+      sys.alarm |= ALARM_HARD_LIMIT;
+      request_report(REQUEST_LIMIT_REPORT, (EXEC_ALARM | EXEC_CRIT_EVENT));
+    }
+  }
+
+ 
+}
 
 /* "The Stepper Driver Interrupt" - This timer interrupt is the workhorse of Grbl. Grbl employs
    the venerable Bresenham line algorithm to manage and exactly synchronize multi-axis moves.
@@ -435,24 +474,7 @@ ISR(TIMER4_COMPA_vect)
     else { sys.position[C_AXIS]++; }
   }
 
-  // While homing or if hard limits enabled
-
-  uint8_t must_stop = ((LIMIT_PIN^limits.expected)&limits.active);
-  if (must_stop) {
-    st.step_outbits &= ~(must_stop>>LIMIT_BIT_SHIFT);
-    if (!st.step_outbits) {
-      limits.ishoming = 0; //if all axes at correct limit state, homing phase is over
-      request_report(REQUEST_STATUS_REPORT|REQUEST_LIMIT_REPORT,LINENUMBER_EMPTY_BLOCK);
-    }
-    //if limits made but not homing , servoing, or alarmed already: critical alarm.
-    if ( !(sys.state & (STATE_ALARM|STATE_HOMING)) && !(sys.state & (STATE_ALARM|STATE_FORCESERVO)) &&
-         bit_isfalse(SYS_EXEC,EXEC_ALARM)) {
-      mc_reset(); // Initiate system kill.
-      // Indicate hard limit critical event, print limits
-      sys.alarm |= ALARM_HARD_LIMIT;
-      request_report(REQUEST_LIMIT_REPORT,(EXEC_ALARM | EXEC_CRIT_EVENT));
-    }
-  }
+  st_limit_check(); //Check for limits
 
   // This checks if desired force value is met while bumping key.
   // Once value is reached, gripper motor will stop.

--- a/stepper.c
+++ b/stepper.c
@@ -286,11 +286,15 @@ void st_limit_check(){
   uint8_t must_stop = (( (LIMIT_PIN) ^ limits.expected) & limits.active);
   if (must_stop) {
     st.step_outbits &= ~(must_stop >> LIMIT_BIT_SHIFT);
-    limits.ishoming &= ~(must_stop >> LIMIT_BIT_SHIFT); // If an axis is done homing, clear the corresponding bit in limits.ishoming
-     
-   if (!limits.ishoming) {
+    limits.ishoming &= ~(must_stop >> LIMIT_BIT_SHIFT); // If an axis is done homing, clear the corresponding bit in limits.ishoming     
+ 
+  if (!limits.ishoming) {
       request_report(REQUEST_STATUS_REPORT|REQUEST_LIMIT_REPORT,LINENUMBER_EMPTY_BLOCK);
-    }
+  } else { 
+    bit_true(sys.state, STATE_HOME_ADJUST);
+
+  }
+
     //if limits made but not homing , servoing, or alarmed already: critical alarm.
     if ( !(sys.state & (STATE_ALARM|STATE_HOMING)) && !(sys.state & (STATE_ALARM|STATE_FORCESERVO)) &&
          bit_isfalse(SYS_EXEC,EXEC_ALARM)) {
@@ -430,9 +434,6 @@ ISR(TIMER4_COMPA_vect)
   }
   // Check probing state.
   probe_state_monitor();
-
-  // Check if mag is missing on the carousel
-  magazine_gap_monitor();
 
   // Reset step out bits.
   st.step_outbits = 0;

--- a/system.c
+++ b/system.c
@@ -272,18 +272,21 @@ uint8_t system_execute_line(char *line)
           break;
         case 'H' : // Perform homing cycle [IDLE/ALARM], only if idle or lost
           if (bit_istrue(settings.flags,BITFLAG_HOMING_ENABLE)) {
+            uint8_t home_mask = 0;
             char axis = line[++char_counter];
             if (axis == '\0' ) {
-              axis = HOMING_CYCLE_ALL; //do all axes if none specified
+              home_mask = HOMING_CYCLE_ALL; //do all axes if none specified
             }
             else {
-              if ( line[++char_counter] != 0 ) { return(STATUS_INVALID_STATEMENT); }
-              axis = get_axis_idx(axis);
-              if (axis == N_AXIS) { return(STATUS_INVALID_STATEMENT); }
-              axis = (1<<axis);  //convert idx to mask
+              while (axis != '\0') {
+                axis = get_axis_idx(axis);
+                if (axis == N_AXIS) { return(STATUS_INVALID_STATEMENT); }
+                home_mask |= (1 << axis); //add axis to homing mask 
+                axis = line[++char_counter]; 
+              }
             }
             report_status_message(STATUS_OK); //report that we are homing
-            mc_homing_cycle(axis);
+            mc_homing_cycle(home_mask);
             if (!sys.abort) { system_execute_startup(line); } // Execute startup scripts after successful homing.
             return STATUS_QUIET_OK; //already said ok
           } else { return(STATUS_SETTING_DISABLED); }

--- a/system.h
+++ b/system.h
@@ -72,6 +72,7 @@
 #define STATE_CYCLE      bit(4) // Cycle is running
 #define STATE_HOLD       bit(5) // Executing feed hold
 #define STATE_FORCESERVO bit(6) // Force servo process
+#define STATE_HOME_ADJUST bit(7) // Update the minimum homing rate when some axes complete homing cycle
 
 // Define Grbl alarm codes. Listed most to least serious
 #define ALARM_SOFT_LIMIT  bit(0) // soft limits exceeded


### PR DESCRIPTION
This addresses point 12 in the [Motion/Grbl Work document](https://docs.google.com/a/key.me/document/d/1mwQOAiM9Z_98V9dCOKPfvVZ9oj25_yXPFzwau3afDOA/edit?usp=sharing).
- Added the ability to address more than one, but not necessarily all axes. For example, the $HYC command will home axis Y and axis C. $H will still home all axes.
- If all axes are selected, the axes are homed sequentially. It is kept this way in case some processes rely on the fact that Grbl homes the axes in a certain order in order to avoid a collision with the bump tower.

However, the axes will home at the lowest speed of the axes that are being homed. For example, the $HYC command will home both Y and C at the speed of the lowest maximum speed, which is the speed of C in this case. To change this, we need to modify how Grbl fundamentally controls the stepper motors in the timer ISR. 

The usefulness of homing axes simultaneously, given the limitation that they need to home at the slowest axis's speed, needs to be investigated.
