### PR TITLE
Fix handling of `M` commands in gcode parser

### DIFF
--- a/gcode.c
+++ b/gcode.c
@@ -318,8 +318,8 @@ uint8_t gc_execute_line(char *line)
         // NOTE: Variable 'word_bit' is always assigned, if the command is valid.
         if ( bit_istrue(command_words,bit(word_bit)) ) { FAIL(STATUS_GCODE_MODAL_GROUP_VIOLATION); }
         bit_true(command_words,bit(word_bit));
-        break;
         }            
+        break;
       
       // NOTE: All remaining letters assign values.
       default: 


### PR DESCRIPTION
With the upcoming ability to load large sections of gcode, we could
theoretically upload the entire program in the form:
(Home=>Select Key=>Grab=>bump=>Position=>Cut=>Release) with an `M00` in
between each state, allowing the cutter to simply issue a continue
command in between stages after validating that they were successful.
