### PR TITLE
Additional small change to 'M' command handling

### DIFF
--- a/gcode.c
+++ b/gcode.c
@@ -313,12 +313,12 @@ uint8_t gc_execute_line(char *line)
             }
             break;
           default: FAIL(STATUS_GCODE_UNSUPPORTED_COMMAND); // [Unsupported M command]
-      
+        }
+
         // Check for more than one command per modal group violations in the current block
         // NOTE: Variable 'word_bit' is always assigned, if the command is valid.
         if ( bit_istrue(command_words,bit(word_bit)) ) { FAIL(STATUS_GCODE_MODAL_GROUP_VIOLATION); }
         bit_true(command_words,bit(word_bit));
-        }            
         break;
       
       // NOTE: All remaining letters assign values.


### PR DESCRIPTION
This brings our parser in line with how upstream grbl handles `M`
commands.
