### PR TITLE
Clean up ADC code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ PORT       ?= /dev/ttyUSB0
 PROGRAMMER ?= -c wiring -P $(PORT) -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
-             print.o probe.o report.o system.o counters.o gqueue.o progman.o
+             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o
+
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 # update that line with this when programmer is back up:
@@ -45,6 +46,10 @@ FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 AVRDUDE = avrdude  $(PROGRAMMER) -p $(DEVICE) -B 10 -F -D
 CFLAGS = -Wall -Werror -Wextra -Os -fstack-usage -DF_CPU=$(CLOCK) -mmcu=$(DEVICE)
 COMPILE = avr-gcc $(CFLAGS) -I. -ffunction-sections
+
+ifneq ($(USE_LOAD_CELL),)
+  CFLAGS += -DUSE_LOAD_CELL
+endif
 
 # symbolic targets:
 all debug:	grbl.hex

--- a/adc.c
+++ b/adc.c
@@ -1,0 +1,69 @@
+
+#include "system.h"
+#include "adc.h"
+#include "nuts_bolts.h"
+
+#define ADMUX_SELECTION_MASK    0x7
+#define MUX5_MASK               0x8
+
+void adc_init()
+{
+
+  // These pins are initialized here because there are 
+  // no other where the pins can be initialized with the
+  // associated peripherals, such as with the stepper motors.
+  
+  #ifdef USE_LOAD_CELL
+    LC_DDR &= ~(LC_MASK);  
+  #else
+    FORCE_DDR &= ~(FORCE_MASK); // Force servo
+  #endif
+
+  // Set revision divider pin as an input
+  RD_DDR &= ~(RD_MASK);
+
+  // Initialize ADCSRA to 0x00
+  ADCSRA = 0x00;
+
+  // Set ADC reference
+  ADMUX |= (1 << REFS0);
+}
+
+uint16_t adc_read_channel(uint8_t channel) 
+{
+  // Select Channel - ADCSRB, MUX5
+  // If the channel number is higher than 7, the MUX5 bit in ADCSRB needs to be set  
+  if (channel & MUX5_MASK) {
+    bit_true(ADCSRB, (1 << MUX5_BIT_POS));
+  } else {
+    bit_false(ADCSRB, (1 << MUX5_BIT_POS));
+  }
+
+  // Clear the previously selected channel
+  ADMUX &= ~(ADMUX_SELECTION_MASK);
+  // Select Channel
+  ADMUX |= (channel & ADMUX_SELECTION_MASK);
+
+  // Enable ADC, Prescaler: 128x
+  ADCSRA = (1 << ADEN) | (1 << ADPS2) | (1 << ADPS1) | (1 << ADPS0);
+  // Enable ADC capture
+  ADCSRA |= (1 << ADSC);
+
+  // Enable capture of ADC with timeout
+  uint16_t timeout = 0xFFFF;
+  while(ADCSRA & (1 << ADSC)) {
+    if (timeout-- == 0) {
+      return 0;
+    }
+  }
+    
+  // Stote the result
+  uint16_t ret = ADC;
+  
+  // Disable ADC 
+  ADCSRA &= ~(1<<ADEN);
+ 
+  // Return result
+  return ret;
+}
+

--- a/adc.h
+++ b/adc.h
@@ -1,0 +1,14 @@
+/*
+  Not part of Grbl, written by KeyMe
+*/
+
+#ifndef adc_h
+#define adc_h
+
+void adc_init();
+
+uint16_t adc_read_channel(uint8_t channel);
+
+
+
+#endif

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -189,14 +189,32 @@
 #define FSCTRL_BIT 5
 
 // Feedback sensor voltage is now analog and called FVOLT
-#define FVOLT_DDR DDRK
-#define FVOLT_PORT PORTK
-#define FVOLT_BIT 7
-#define FVOLT_MASK (1<<FVOLT_BIT)
+#define FORCE_DDR DDRK
+#define FORCE_BIT 7
+#define FORCE_PORT PORTK
+#define FORCE_MASK (1 << FORCE_BIT)
 
-#define FVOLT_ADC 7  // value to write to ADCSRA to read ADC15
-#define MUX5_BIT_POS 3
-#define MUX5_BIT_VALUE 1 // 1 designates ADC 15
+// ADC Selection
+#define F_ADC          15 // ADC 15 - Force
+#define X_ADC           1  // ADC 1 - X axis
+#define Y_ADC           2  // ADC 2 - Y axis
+#define Z_ADC           3  // ADC 3 - Z axis
+#define C_ADC           0  // ADC 0 - C axis
+#define RD_ADC          4  // ADC 4 Revision voltage divider - RevDiv
+#define LC_ADC          7  // ADC 7 Load Cell
+#define MUX5_BIT_POS    3  // This bit needs to be set in ADCSRB if the ADC channel is between 8 and 15
+
+// Load cell analog input
+#define LC_DDR DDRF
+#define LC_PORT PORTF
+#define LC_BIT 7
+#define LC_MASK (1 << LC_BIT) 
+
+// Revision voltage divider - 0.5V per division
+#define RD_DDR DDRF
+#define RD_PORT PORTF
+#define RD_BIT 4
+#define RD_MASK (1 << RD_BIT)
 
 // Measurement of Supply Voltage for all motors, MVOLT
 #define MVOLT_DDR DDRF
@@ -206,11 +224,6 @@
 #define Y_MVOLT_BIT 2
 #define Z_MVOLT_BIT 3
 #define C_MVOLT_BIT 0
-
-#define X_MVOLT_ADC 1
-#define Y_MVOLT_ADC 2
-#define Z_MVOLT_ADC 3
-#define C_MVOLT_ADC 0
 
 #define MVOLT_MASK ((1<<X_MVOLT_BIT)|(1<<Y_MVOLT_BIT)|(1<<Z_MVOLT_BIT)|(1<<C_MVOLT_BIT))
 

--- a/main.c
+++ b/main.c
@@ -35,7 +35,7 @@
 #include "report.h"
 #include "counters.h"
 #include "progman.h"
-
+#include "adc.h"
 
 // Declare system global variable structure
 system_t sys;
@@ -50,6 +50,7 @@ int main(void)
   stepper_init();  // Configure stepper pins and interrupt timers
   system_init();   // Configure pinout pins and pin-change interrupt
   counters_init(); //configure encoder and counter interrupt.
+  adc_init();
 
   memset(&sys, 0, sizeof(sys));  // Clear all system variables
   memset((void*)&sysflags, 0, sizeof(sysflags));  // and volatile
@@ -88,6 +89,8 @@ int main(void)
     plan_reset(); // Clear block buffer and planner variables
     st_reset(); // Clear stepper subsystem variables.
     progman_init();
+    report_revision(); // ADC - read revision voltage form revision voltage divider  
+  
 
     // Sync cleared gcode and planner positions to current system position.
     plan_sync_position();

--- a/protocol.c
+++ b/protocol.c
@@ -155,6 +155,9 @@ void protocol_execute_runtime()
 
   /* Give the program manager some time to manage the serial traffic */
   progman_execute();
+  
+  // Update force sensor voltage
+  calculate_force_voltage();
 
   if (clock >= (report_clock +  STATUS_REPORT_RATE_MS) || clock < report_clock) {
     rt_exec|= EXEC_RUNTIME_REPORT;
@@ -273,8 +276,6 @@ void protocol_execute_runtime()
   // Reload step segment buffer
   if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING | STATE_FORCESERVO))
   { st_prep_buffer(); }
-
-  calculate_force_voltage();
 
   // Clear IO Reset bit.
   IO_RESET_PORT &= (~IO_RESET_MASK);

--- a/report.h
+++ b/report.h
@@ -87,16 +87,22 @@ uint8_t report_realtime_status();
 // Prints state of limit pins and estop
 void report_limit_pins();
 
-// Prinst state of counters
+// Prints state of counters
 void report_counters();
 
-// Prinst voltage of motors
+// Read voltage of ADCs
+
 void report_voltage();
 void calculate_motor_voltage();
 void calculate_force_voltage();
+void report_revision();
+
 // Variable for holding voltage value after ADC
+
 uint16_t analog_voltage_readings[VOLTAGE_SENSOR_COUNT];
+
 #define FORCE_VALUE_INDEX 4 // Index of analog_voltage_readings that holds force value
+#define REV_VALUE_INDEX 5
 
 // Prints recorded probe position
 void report_probe_parameters(uint8_t error);

--- a/stepper.c
+++ b/stepper.c
@@ -566,12 +566,6 @@ void keyme_init() {
   // MVOLT is used for voltage sensing
   // TODO:  read on command.  (create command)
   MVOLT_DDR &= ~(MVOLT_MASK);
-  MVOLT_PORT |= MVOLT_MASK; // internal pull-up, normal high
-
-  // FDBK is for additional 1 voltage sensor (gripper force feedback)
-  // Feedback sensor voltage is called FVOLT
-  FVOLT_DDR |= ~(FVOLT_MASK);
-  FVOLT_PORT |= FVOLT_MASK;  // internal pull-up????  it's an analog
 
   // Setup CCTRL (current control) ports
   // TODO: make this output PWMs with configurable values

--- a/system.h
+++ b/system.h
@@ -167,7 +167,7 @@ enum {
 #define TIME_TOGGLE(tid)  (((tid)==ACTIVE_TIMER)?(TIMING_PIN|=TIMING_MASK):(void)tid)
 
 // Voltage Monitoring
-#define VOLTAGE_SENSOR_COUNT 5 // number of devices (X,Y,Z,C,F) for which voltage is measured
+#define VOLTAGE_SENSOR_COUNT 6 // number of devices (X,Y,Z,C,F,RD) for which voltage is measured
 // Reasoning for commenting this function is in system.c.
 //void init_ADC();
 


### PR DESCRIPTION
Cleaned up the ADC code. The way ADCs channels were selected previously was hard-coded. 

For example, the force ADC is on channel 15. The three LSBs need to be written to ADMUX and the MSB to the MUX5 bit ins ADCSRB. It was hardcoded as a 1 for MUX5_bit and 0x7 for the selection bits in ADMUX. This does not make the code very modular - what if we want to read from ADC7, but the MUX5 bit is hardcoded in a #define?

These logic operations were abstracted from the functions in reports.c and also from the definitions of ADC channels in cpu_map_keyme2560.h.

The low-level interaction with ADC registers was also abstracted into separate files. This is the first step in using the load cell to get gripper force readings.
