### PR TITLE
Home axes simultaneously

### DIFF
--- a/config.h
+++ b/config.h
@@ -79,12 +79,13 @@
 // on separate pin, but homed in one cycle. Also, it should be noted that the function of hard limits
 // will not be affected by pin sharing.
 // NOTE: CYCLE is set for the keyme machine.  Gripper open first. Then Y, then X & Carousel
-#define HOMING_CYCLE_0 (1<<X_AXIS)                // REQUIRED: First move X
-#define HOMING_CYCLE_1 (1<<Y_AXIS)                // Clear Y Axis
-#define HOMING_CYCLE_2 ((1<<Z_AXIS)|(1<<C_AXIS))  // Z and carousel ok at same time.
+#define HOMING_CYCLE_0 (1 << X_AXIS)   // REQUIRED: First move X
+#define HOMING_CYCLE_1 (1 << Y_AXIS)   
+#define HOMING_CYCLE_2 (1 << Z_AXIS)   // Gripper
+#define HOMING_CYCLE_3 (1 << C_AXIS)
 
 
-#define HOMING_CYCLE_ALL  (HOMING_CYCLE_0|HOMING_CYCLE_1|HOMING_CYCLE_2)
+#define HOMING_CYCLE_ALL  (HOMING_CYCLE_0 | HOMING_CYCLE_1 | HOMING_CYCLE_2 | HOMING_CYCLE_3)
 // Number of homing cycles performed after when the machine initially jogs to limit switches.
 // This help in preventing overshoot and should improve repeatability. This value should be one or
 // greater.

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -9,10 +9,10 @@
 #define SERIAL_UDRE USART0_UDRE_vect
 
 // Increase Buffers to make use of extra SRAM
-#define RX_BUFFER_SIZE		255
-#define TX_BUFFER_SIZE		128
-#define BLOCK_BUFFER_SIZE	48
-#define LINE_BUFFER_SIZE	255
+#define RX_BUFFER_SIZE          255
+#define TX_BUFFER_SIZE          128
+#define BLOCK_BUFFER_SIZE       48
+#define LINE_BUFFER_SIZE        255
 
 // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
 #define STEP_DDR      DDRH

--- a/limits.c
+++ b/limits.c
@@ -27,6 +27,7 @@
 #include "motion_control.h"
 #include "limits.h"
 #include "report.h"
+#include "magazine.h"
 
 #define HOMING_AXIS_SEARCH_SCALAR  1.1  // Axis search distance multiplier. Must be > 1.
 
@@ -77,6 +78,7 @@ void limits_enable(uint8_t axes, uint8_t expected) {
   limits.expected = bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS)?~expected:expected;
   limits.active = axes<<LIMIT_BIT_SHIFT;
   limits.mag_gap_check = MAG_GAP_CHECK_ENABLE;
+  memcpy(sys.probe_position, sys.position, sizeof(float) * N_AXIS);
 }
 
 
@@ -87,6 +89,60 @@ void limits_disable()
   limits.active = 0;
 }
 
+// Called from limits_go_home
+void limits_update_homing_values(uint8_t cycle_mask, float * homing_rate, float * min_seek_rate, uint8_t * axislock, float * max_travel, uint8_t * n_active_axis)
+{
+  uint8_t idx;
+  for (idx = 0; idx < N_AXIS; idx++) {
+    if (bit_istrue(cycle_mask, bit(idx))) {
+      (*n_active_axis)++;
+      *axislock |= (1 << (X_STEP_BIT + idx)); //assumes axes are in bit order.
+      *max_travel = max(*max_travel, settings.max_travel[idx]);
+      *min_seek_rate = min(*min_seek_rate, settings.homing_seek_rate[idx]);
+    }
+  }
+  *max_travel *= HOMING_AXIS_SEARCH_SCALAR; // Ensure homing switches engaged by over-estimating max travel.
+  *max_travel += settings.homing_pulloff;
+  *homing_rate = *min_seek_rate * sqrt(*n_active_axis); //Adjust so individual axes all move at homing rate.
+
+  return;
+}
+
+// Called from limits_go_home
+void limits_plan_homing(uint8_t cycle_mask, float homing_rate, float max_travel, uint8_t axislock, uint8_t approach, float* target, uint8_t flipped)
+{
+ 
+  uint8_t idx;
+  
+  // Set target location and rate for active axes.
+  // and reset homing axis locks based on cycle mask.
+
+  // limit travel distance to the length of the largest flag
+  float travel = approach ? max_travel : MAXFLAGLEN;
+  // set target for moving axes based on direction
+  for (idx = 0; idx < N_AXIS; idx++) {
+    if (bit_istrue(cycle_mask, bit(idx))) {
+      if ((flipped & (1 << idx)) ^ approach) {
+        target[idx] = -travel;
+      } else {
+        target[idx] = travel;
+      }
+    } else {
+      target[idx] = 0;
+    }
+  }
+
+  // Perform homing cycle. Planner buffer should be empty, as required to initiate the homing cycle.
+  plan_buffer_line(target, homing_rate, false, LINENUMBER_EMPTY_BLOCK);  // Bypass mc_line(). Directly plan homing motion.
+
+  // axislock bit is high if axis is homing, so we only enable checking on moving axes.
+  limits_enable(axislock,~approach);  //expect 0 on approach (stop when 1). vice versa for pulloff
+  limits.ishoming = axislock << LIMIT_BIT_SHIFT;
+ 
+  st_prep_buffer(); // Prep and fill segment buffer from newly planned block.
+  st_wake_up(); // Initiate motion
+
+}
 
 // Limit checking moved to stepper ISR. 
 // limits_enable() sets limits.active and limits.expected flags.
@@ -118,10 +174,10 @@ void limits_go_home(uint8_t cycle_mask)
   // Initialize homing in search mode to quickly engage the specified cycle_mask limit switches.
   uint8_t approach = ~0;  //approach has all bits set (negative dir) or none (positive)
   uint8_t idx;
-  uint8_t n_cycle = (2*N_HOMING_LOCATE_CYCLE);
+  uint8_t n_cycle = (2 * N_HOMING_LOCATE_CYCLE);
   float target[N_AXIS];
 
-  uint8_t flipped = settings.homing_dir_mask>>X_DIRECTION_BIT;  //assumes keyme configuration.
+  uint8_t flipped = settings.homing_dir_mask >> X_DIRECTION_BIT;  //assumes keyme configuration.
   //replace with an instance of `if (bitistrue(h_d_m,X_DIRECTION_BIT)) { flipped|=1<<X_AXIS;}` 
   //for each axis if the bits line up differently
 
@@ -131,51 +187,38 @@ void limits_go_home(uint8_t cycle_mask)
   uint8_t n_active_axis = 0;
   uint8_t axislock = 0;
 
-  for (idx=0; idx<N_AXIS; idx++){
-    if (bit_istrue(cycle_mask,bit(idx))) {
-      n_active_axis++;
-      axislock |= (1<<(X_STEP_BIT+idx)); //assumes axes are in bit order.
-      max_travel = max(max_travel,settings.max_travel[idx]);
-      min_seek_rate = min(min_seek_rate,settings.homing_seek_rate[idx]);
-    }
-  }
-  max_travel *= HOMING_AXIS_SEARCH_SCALAR; // Ensure homing switches engaged by over-estimating max travel.
-  max_travel += settings.homing_pulloff;
-  homing_rate = min_seek_rate * sqrt(n_active_axis); //Adjust so individual axes all move at homing rate.
+  limits_update_homing_values(cycle_mask, &homing_rate, &min_seek_rate, &axislock, &max_travel, &n_active_axis);
   plan_reset(); // Reset planner buffer to zero planner current position and to clear previous motions.
 
   do {
-    // Set target location and rate for active axes.
-    // and reset homing axis locks based on cycle mask.
-
-    // limit travel distance to the length of the largest flag
-    float travel = approach ? max_travel : MAXFLAGLEN;
-    // set target for moving axes based on direction
-    for (idx=0; idx<N_AXIS; idx++) {
-      if (bit_istrue(cycle_mask,bit(idx))) {
-        if ((flipped&(1<<idx))^approach) {
-          target[idx] = -travel;
-        }
-        else {
-          target[idx] = travel;
-        }
-      }
-      else {
-        target[idx] = 0;
-      }
-    }
-
-    // Perform homing cycle. Planner buffer should be empty, as required to initiate the homing cycle.
-    plan_buffer_line(target, homing_rate, false, LINENUMBER_EMPTY_BLOCK);  // Bypass mc_line(). Directly plan homing motion.
-
-    // axislock bit is high if axis is homing, so we only enable checking on moving axes.
-    limits_enable(axislock,~approach);  //expect 0 on approach (stop when 1). vice versa for pulloff
-    limits.ishoming = 1;
-
-    st_prep_buffer(); // Prep and fill segment buffer from newly planned block.
-    st_wake_up(); // Initiate motion
+    limits_plan_homing(cycle_mask, homing_rate, max_travel, axislock, approach, target, flipped);
 
     do {
+      
+      // Monitor magazine probe to look for missing magazines on carousel
+      magazine_gap_monitor();
+
+      // If the home speed needs to be adjusted when an axis finishes homing,
+      // calculate new homing values and reset the plan buffer
+      if (bit_istrue(sys.state, STATE_HOME_ADJUST)) {
+       
+        limits_disable();
+        st_reset();
+        plan_reset(); // Reset planner buffer to zero planner current position and to clear previous motions.
+
+        min_seek_rate = 1e9; //arbitrary maximum=1km/s, will be reduced by axis setting below
+        max_travel = 0;
+        n_active_axis = 0;
+        axislock = 0;
+        
+        limits_update_homing_values(limits.ishoming, &homing_rate, &min_seek_rate, &axislock, &max_travel, &n_active_axis);
+
+        limits_plan_homing(limits.ishoming, homing_rate, max_travel, axislock, approach, target, flipped);
+
+        // Clear the STATE_HOME_ADJUST flag when homing is adjusted
+        bit_false(sys.state, STATE_HOME_ADJUST);
+      }
+
       st_prep_buffer(); // Check and prep segment buffer. NOTE: Should take no longer than 200us.
       // Check only for user reset. Keyme: fixed to allow protocol_execute_runtime() in this loop.
       protocol_execute_runtime();

--- a/magazine.c
+++ b/magazine.c
@@ -30,6 +30,7 @@ void magazine_gap_monitor()
 
   if(limits.mag_gap_check == 0)
     return;
+
   // Activate alarm if the gap between the current position and the previous
   // probe position becomes too large. Only do this when the system has already homed
   const int32_t cur_pos = sys.position[C_AXIS];

--- a/motion_control.c
+++ b/motion_control.c
@@ -224,17 +224,8 @@ void mc_homing_cycle(uint8_t axis_mask)
   // -------------------------------------------------------------------------------------
   // Perform homing routine. NOTE: Special motion case. Only system reset works.
   
-  // Search to engage all axes limit switches at faster homing seek rate.
-  limits_go_home(HOMING_CYCLE_0&axis_mask);  // Homing cycle 0
-  #ifdef HOMING_CYCLE_1
-    limits_go_home(HOMING_CYCLE_1&axis_mask);  // Homing cycle 1
-  #endif
-  #ifdef HOMING_CYCLE_2
-    limits_go_home(HOMING_CYCLE_2&axis_mask);  // Homing cycle 2
-  #endif
-
-
-    
+  limits_go_home(axis_mask);
+      
   protocol_execute_runtime(); // Check for reset and set system abort.
   if (sys.abort) { return; } // Did not complete. Alarm state set by mc_alarm.
 

--- a/system.c
+++ b/system.c
@@ -275,18 +275,23 @@ uint8_t system_execute_line(char *line)
           break;
         case 'H' : // Perform homing cycle [IDLE/ALARM], only if idle or lost
           if (bit_istrue(settings.flags,BITFLAG_HOMING_ENABLE)) {
+            uint8_t home_mask = 0;
             char axis = line[++char_counter];
             if (axis == '\0' ) {
-              axis = HOMING_CYCLE_ALL; //do all axes if none specified
+              home_mask = HOMING_CYCLE_ALL; //do all axes if none specified
             }
             else {
-              if ( line[++char_counter] != 0 ) { return(STATUS_INVALID_STATEMENT); }
-              axis = get_axis_idx(axis);
-              if (axis == N_AXIS) { return(STATUS_INVALID_STATEMENT); }
-              axis = (1<<axis);  //convert idx to mask
+              while (axis != '\0') {
+                axis = get_axis_idx(axis);
+                if (axis == N_AXIS) { return(STATUS_INVALID_STATEMENT); }
+                home_mask |= (1 << axis); //add axis to homing mask 
+                axis = line[++char_counter]; 
+              }
             }
-            mc_homing_cycle(axis);
-            if (!sys.abort) { system_execute_startup(line); } // Execute startup scripts after successful homing.
+            report_status_message(STATUS_OK); //report that we are homing
+            mc_homing_cycle(home_mask);
+            
+          if (!sys.abort) { system_execute_startup(line); } // Execute startup scripts after successful homing.
             return STATUS_QUIET_OK; //already said ok
           } else { return(STATUS_SETTING_DISABLED); }
           break;

--- a/system.h
+++ b/system.h
@@ -72,6 +72,7 @@
 #define STATE_CYCLE      bit(4) // Cycle is running
 #define STATE_HOLD       bit(5) // Executing feed hold
 #define STATE_FORCESERVO bit(6) // Force servo process
+#define STATE_HOME_ADJUST bit(7) // Update the minimum homing rate when some axes complete homing cycle
 
 // Define Grbl alarm codes. Listed most to least serious
 #define ALARM_SOFT_LIMIT  bit(0) // soft limits exceeded


### PR DESCRIPTION
This addresses point 12 in the [Motion/Grbl Work document](https://docs.google.com/a/key.me/document/d/1mwQOAiM9Z_98V9dCOKPfvVZ9oj25_yXPFzwau3afDOA/edit?usp=sharing).
- Added the ability to address more than one, but not necessarily all axes. For example, the $HYC command will home axis Y and axis C. $H will still home all axes.
- If multiple axes are homed simultaneously, all axes will home at the speed of the slowest axis (this is unfortunately a limitation based on how Grbl implements its stepping ISR - it can be changed, but requires a significant rewrite of a fundamental part of Grbl).
- However, when an axis finishes homing, while one or more other axes are still homing, the homing rate will be adjusted based on the now slowest axis that's busy homing. Overall, this is an improvement in homing time.

Furthermore, the magazine alignment probe checking was moved out of the already very long stepper ISR to make it more efficient. 
