### PR TITLE
Add SPI driver and initial SPI stepper driver setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PORT       ?= /dev/ttyUSB0
 PROGRAMMER ?= -c wiring -P $(PORT) -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
-             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o
+             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o spi.o
 
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
@@ -46,6 +46,10 @@ FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 AVRDUDE = avrdude  $(PROGRAMMER) -p $(DEVICE) -B 10 -F -D
 CFLAGS = -Wall -Werror -Wextra -Os -fstack-usage -DF_CPU=$(CLOCK) -mmcu=$(DEVICE)
 COMPILE = avr-gcc $(CFLAGS) -I. -ffunction-sections
+
+ifneq ($(SPI),)
+  CFLAGS += -DSPI_STEPPER_DRIVER
+endif
 
 ifneq ($(USE_LOAD_CELL),)
   CFLAGS += -DUSE_LOAD_CELL

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -14,6 +14,24 @@
 #define BLOCK_BUFFER_SIZE       48
 #define LINE_BUFFER_SIZE        255
 
+//Slave Chip Selects for stepper motors
+#define SCS_XTABLE_PIN          PC6
+#define SCS_YTABLE_PIN          PC5
+#define SCS_CAROUSEL_PIN        PC7
+#define SCS_GRIPPER_PIN         PC4
+#define SCS_MASK  (1 << SCS_XTABLE_PIN) | (1 << SCS_YTABLE_PIN) | (1 << SCS_CAROUSEL_PIN) | (1 << SCS_GRIPPER_PIN)
+
+// Note - All steppers need to be on the same port,
+// if not, use the commented section below
+#define SCS_PORT        PORTC
+#define SCS_DDR_PORT    DDRC
+
+#define SCS_XTABLE_DDR_PIN      DDC6
+#define SCS_YTABLE_DDR_PIN      DDC5
+#define SCS_CAROUSEL_DDR_PIN    DDC7
+#define SCS_GRIPPER_DDR_PIN     DDC4
+#define SCS_DDR_MASK (1 << SCS_XTABLE_DDR_PIN) | (1 << SCS_YTABLE_DDR_PIN) | (1 << SCS_CAROUSEL_DDR_PIN) | (1 << SCS_GRIPPER_DDR_PIN)
+
 // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
 #define STEP_DDR      DDRH
 #define STEP_PORT     PORTH

--- a/main.c
+++ b/main.c
@@ -36,6 +36,7 @@
 #include "counters.h"
 #include "progman.h"
 #include "adc.h"
+#include "spi.h"
 
 // Declare system global variable structure
 system_t sys;
@@ -46,6 +47,10 @@ int main(void)
 {
   // Initialize system upon power-up.
   serial_init();   // Setup serial baud rate and interrupts
+  #ifdef SPI_STEPPER_DRIVER
+    spi_init();      // Setup SPI Control register and pins
+  #endif
+
   settings_init(); // Load grbl settings from EEPROM
   stepper_init();  // Configure stepper pins and interrupt timers
   system_init();   // Configure pinout pins and pin-change interrupt

--- a/serial.c
+++ b/serial.c
@@ -66,7 +66,8 @@ void serial_init()
 
 
 
-void serial_sendchar(uint8_t data) {
+void serial_sendchar(uint8_t data) 
+{
   // Calculate next head
   uint8_t next_head = tx_buffer_head + 1;
   if (next_head == TX_BUFFER_SIZE) { next_head = 0; }
@@ -83,13 +84,15 @@ void serial_sendchar(uint8_t data) {
   UCSR0B |=  (1 << UDRIE0);
 }
 
-void serial_write(uint8_t data) {
-  checksum+=data;
+void serial_write(uint8_t data)
+{
+  checksum += data;
   serial_sendchar(data);
   if (data == '\n') {
     serial_sendchar(checksum);
     checksum = 0;
   }
+
 }
 
 
@@ -144,8 +147,8 @@ ISR(SERIAL_RX)
 
   // Write data to buffer unless it is full.
   if (next_head != rx_buffer_tail) {
-	  rx_buffer[rx_buffer_head] = data;
-	  rx_buffer_head = next_head;
+    rx_buffer[rx_buffer_head] = data;
+    rx_buffer_head = next_head;
 
   }
   //TODO: else alarm on overflow?

--- a/spi.c
+++ b/spi.c
@@ -1,0 +1,62 @@
+/* 
+  Not part of GRBL, KeyMe specific
+*/
+
+#include "spi.h"
+
+#define SPI_TRANSFER_FLAG (SPSR & (1<<SPIF))
+
+
+//Setup spi
+void spi_init()
+{
+
+  DDRB = ((1 << DDB2) | (1 << DDB1) | (1 << DDB0)); //spi pins on port b MOSI SCK,SS outputs
+
+  SPCR = ((1 << SPE) | (1 << MSTR) | (1 << SPR0) | (1 << CPOL) | (1 << CPHA));  // SPI enable, Master, f/16
+
+  //Configure SCS Pins as outputs
+  bit_true(SCS_DDR_PORT, SCS_DDR_MASK); 
+
+  //Set SCS to low for all steppers
+  bit_false(SCS_PORT, SCS_MASK);
+
+}
+
+void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len)
+{
+
+  uint8_t idx;
+
+  for(idx = 0; idx < len; idx++) {
+
+    if (dataout != NULL) {
+      SPDR = dataout[idx];  //SPDR - SPI Data register
+    } else {
+      SPDR = 0;    
+    }
+
+    uint16_t timeout = 0xFFFF;
+    while(!(SPI_TRANSFER_FLAG)) {
+      if (timeout-- == 0) {
+        return;     
+      }
+    } //Wait for transmit to be completed
+
+    if (datain != NULL) {
+      datain[idx] = SPDR;
+    } 
+  
+  }
+}
+
+void spi_read(uint8_t * datain, uint8_t len) 
+{
+  spi_transact_array(NULL, datain, len);
+}
+
+void spi_write(uint8_t * dataout, uint8_t len)
+{
+  spi_transact_array(dataout, NULL, len);
+}
+

--- a/spi.h
+++ b/spi.h
@@ -1,0 +1,38 @@
+/*
+  Not part of GRBL, KeyMe specific
+*/
+
+#ifndef _SPI_H_
+#define _SPI_H_
+
+#include <avr/io.h>
+#include "system.h"
+
+
+#define SPI_PORT        PORTB
+#define SPI_DDR         DDRB
+#define DD_MISO         DDB3
+#define DD_MOSI         DDB2
+#define DD_SCK          DDB1
+#define DD_SS           DDB0
+
+#define C_SPIE 0        //SPI Interrupt Enable
+#define C_SPE  1        //SPI Enable
+#define C_DORD 0        //SPI Data Order; 1 - LSB of word transmitted first; 0 - MSB first
+#define C_MSTR 1        //1 - Master SPI mode; 0 - Slave SPI mode
+#define C_CPOL 0        //Clock polarity; 1 - SCK is high when IDLE; 0 - low
+#define C_CPHA 0        //1 - Leading edge setup, Trailing edge sample; 0 - vice versa
+#define C_SPR1 0        //Control SCK rate - selected as TODO: configure SPI Clock Rate
+#define C_SPR0 1
+
+void spi_init();
+
+// Transmit an array of bytes and receive a byte for each byte transmitted
+void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len);
+
+// Wrapper function for spi_transact_array, but no data is sent
+void spi_read(uint8_t * datain, uint8_t len);
+
+// Wrapper function for spi_transact_array, but not data is expected back
+void spi_write(uint8_t * dataout, uint8_t len);
+#endif //H_


### PR DESCRIPTION
Added SPI driver. The exact values with which the driver ICs need to be setup need to be changed and tested once we get the new hardware.

The SPI code is compiled when you run `make SPI=1` and not compiled when the `SPI=1` part is left out.
