### PR TITLE
Add magazine gap checking to eeprom

### DIFF
--- a/limits.c
+++ b/limits.c
@@ -77,7 +77,7 @@ void limits_enable(uint8_t axes, uint8_t expected) {
   //    LIMIT_PCMSK |= LIMIT_MASK; // Enable specific pins of the Pin Change Interrupt
   limits.expected = bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS)?~expected:expected;
   limits.active = axes<<LIMIT_BIT_SHIFT;
-  limits.mag_gap_check = MAG_GAP_CHECK_ENABLE;
+  limits.mag_gap_check = settings.mag_gap_enabled;
   memcpy(sys.probe_position, sys.position, sizeof(float) * N_AXIS);
 }
 
@@ -194,10 +194,6 @@ void limits_go_home(uint8_t cycle_mask)
     limits_plan_homing(cycle_mask, homing_rate, max_travel, axislock, approach, target, flipped);
 
     do {
-      
-      // Monitor magazine probe to look for missing magazines on carousel
-      magazine_gap_monitor();
-
       // If the home speed needs to be adjusted when an axis finishes homing,
       // calculate new homing values and reset the plan buffer
       if (bit_istrue(sys.state, STATE_HOME_ADJUST)) {
@@ -409,6 +405,6 @@ void limits_force_servo(){
   
   plan_sync_position(); // Sync planner position to current machine position for pull-off move.
 
-  limits.mag_gap_check = MAG_GAP_CHECK_ENABLE; // Start checking magazine gaps on carousel again
+  limits.mag_gap_check = settings.mag_gap_enabled; // Start checking magazine gaps on carousel again
 }
 /* KEYME SPECIFIC END */

--- a/report.c
+++ b/report.c
@@ -223,6 +223,10 @@ void report_grbl_settings() {
   printPgmString(PSTR(" (decay mode, (0..3))"));
   printPgmString(PSTR("\r\n$39=")); print_uint8_base10(settings.force_sensor_level);
   printPgmString(PSTR(" (force sensor level, (0..255))"));
+  printPgmString(PSTR("\r\n$40=")); printFloat_SettingValue(settings.mag_gap_limit);
+  printPgmString(PSTR(" (magazine gap limit, mm)"));
+  printPgmString(PSTR("\r\n$41=")); print_uint8_base10(settings.mag_gap_enabled);
+  printPgmString(PSTR(" (magazine gap enabled, bool)"));
   /* End KEYME Specific */
   printPgmString(PSTR("\r\n"));
 }

--- a/settings.c
+++ b/settings.c
@@ -239,6 +239,8 @@ uint8_t settings_store_global_setting(int parameter, float value) {
     case 37: settings.microsteps = value; break;
     case 38: settings.decay_mode = value; break;
     case 39: settings.force_sensor_level = value; break;
+    case 40: settings.mag_gap_limit = value; break;
+    case 41: settings.mag_gap_enabled = value; break;
     default:
       return(STATUS_INVALID_STATEMENT);
   }

--- a/settings.h
+++ b/settings.h
@@ -84,7 +84,8 @@ typedef struct {
   uint8_t microsteps; //2 bits per motor
   uint8_t decay_mode; //0..3  slow-->fast
   uint8_t force_sensor_level; //0..255  low-->high sensitivity
-  uint8_t mag_gap_limit;
+  float mag_gap_limit; // Maximum gap between two magazines at which point an alarm is thrown
+  uint8_t mag_gap_enabled; //If 0, then do not check the gap between magazines
 //  uint8_t status_report_mask; // Mask to indicate desired report data.
 } settings_t;
 extern settings_t settings;

--- a/stepper.c
+++ b/stepper.c
@@ -506,6 +506,11 @@ ISR(TIMER4_COMPA_vect)
   // Check probing state.
   probe_state_monitor();
 
+  if(settings.mag_gap_enabled) {
+   // Monitor magazine probe to look for missing magazines on carousel
+   magazine_gap_monitor();
+  }
+
   // Reset step out bits.
   st.step_outbits = 0;
 


### PR DESCRIPTION
Requires: https://github.com/keyme/kiosk/pull/8299

Add magazine gap monitoring variables to eeprom settings.

The two variables are:
- mag_gap_limit - This is a float value that specifies the limit in the gap between two magazine flags before an alarm is thrown.
- mag_gap_enabled - A flag that enables magazine gap monitoring.

This change will allow us to disable magazine gap monitoring or update the maximum distance between two magazines in the field .

Also - moved magazine gap monitoring back to the stepper ISR, since magazine gap checking only worked while homing otherwise.
