### PR TITLE
Add ADC filtering and systick callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PORT       ?= /dev/ttyUSB0
 PROGRAMMER ?= -c wiring -P $(PORT) -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
-             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o spi.o
+             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o spi.o signals.o systick.o
 
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m

--- a/adc.h
+++ b/adc.h
@@ -1,5 +1,5 @@
 /*
-  Not part of Grbl, written by KeyMe
+  Not part of Grbl. KeyMe specific
 */
 
 #ifndef adc_h
@@ -8,7 +8,5 @@
 void adc_init();
 
 uint16_t adc_read_channel(uint8_t channel);
-
-
 
 #endif

--- a/limits.c
+++ b/limits.c
@@ -27,6 +27,7 @@
 #include "motion_control.h"
 #include "limits.h"
 #include "report.h"
+#include "signals.h"
 #include "magazine.h"
 
 #define HOMING_AXIS_SEARCH_SCALAR  1.1  // Axis search distance multiplier. Must be > 1.
@@ -408,3 +409,4 @@ void limits_force_servo(){
   limits.mag_gap_check = settings.mag_gap_enabled; // Start checking magazine gaps on carousel again
 }
 /* KEYME SPECIFIC END */
+

--- a/main.c
+++ b/main.c
@@ -37,11 +37,12 @@
 #include "progman.h"
 #include "adc.h"
 #include "spi.h"
+#include "systick.h"
+#include "signals.h"
 
 // Declare system global variable structure
 system_t sys;
 volatile sys_flags_t sysflags;
-
 
 int main(void)
 {
@@ -51,10 +52,11 @@ int main(void)
     spi_init();      // Setup SPI Control register and pins
   #endif
 
+
   settings_init(); // Load grbl settings from EEPROM
   stepper_init();  // Configure stepper pins and interrupt timers
   system_init();   // Configure pinout pins and pin-change interrupt
-  counters_init(); //configure encoder and counter interrupt.
+  counters_init(); // Configure encoder and counter interrupt.
   adc_init();
 
   memset(&sys, 0, sizeof(sys));  // Clear all system variables
@@ -94,8 +96,14 @@ int main(void)
     plan_reset(); // Clear block buffer and planner variables
     st_reset(); // Clear stepper subsystem variables.
     progman_init();
-    report_revision(); // ADC - read revision voltage form revision voltage divider  
-  
+    systick_init();  // Init systick and systick callbacks
+
+    // Register first signals update callback
+    systick_register_callback(500, signals_callback); // Start polling ADCs 0.5 seconds after init
+
+    // Read revision voltage from revision voltage divider
+    // This ADC is not read continuously
+    signals_update_revision();    
 
     // Sync cleared gcode and planner positions to current system position.
     plan_sync_position();

--- a/motion_control.c
+++ b/motion_control.c
@@ -248,7 +248,7 @@ void mc_homing_cycle(uint8_t axis_mask)
   limits_configure();
 }
 
-// Wrapper function for force servoing. This mimics the homing cycle.
+// Wrapper function for limits_force_servo. This mimics the homing cycle.
 void mc_force_servo_cycle()
 {
   sys.state = STATE_FORCESERVO; // Set system state variable
@@ -256,8 +256,11 @@ void mc_force_servo_cycle()
     
   // Perform force servoing.
   limits_force_servo();
+  
   protocol_execute_runtime(); // Check for reset and set system abort.
-  if (sys.abort) { return; } // Did not complete. Alarm state set by mc_alarm.
+  if (sys.abort) { 
+    return; 
+  } // Did not complete. Alarm state set by mc_alarm.
   // Force Servoing Complete! Setup system for normal operation.
 
   // Gcode parser position was circumvented by the limits_force_servo() routine, so sync position now.

--- a/report.c
+++ b/report.c
@@ -37,8 +37,7 @@
 #include "stepper.h"
 #include "counters.h"
 #include "probe.h"
-#include "adc.h"
-
+#include "signals.h"
 
 // Handles the primary confirmation protocol response for streaming interfaces and human-feedback.
 // For every incoming line, this method responds with an 'ok' for a successful command or an
@@ -390,7 +389,6 @@ void report_counters()
 void report_voltage()
 {
   uint8_t i;
-  calculate_motor_voltage();
   printPgmString( PSTR("|") );
   for (i = 0; i < VOLTAGE_SENSOR_COUNT; i++) {
     printInteger((uint32_t)analog_voltage_readings[i]);
@@ -400,35 +398,6 @@ void report_voltage()
   printPgmString(PSTR("|"));
   printPgmString(PSTR("\r\n"));
 }
-
-// Calculates voltage at motors. Only called in report_voltage().
-void calculate_motor_voltage(){
-  uint8_t i;
-
-  for (i = 0; i < N_AXIS; i++) {
-    // Assumes the motors are on ADC channels 0-3 and in the same
-    // order in analog_voltage_readings If the pins are changed, a
-    // map should be made to motors to ADC channels.
-    analog_voltage_readings[i] = adc_read_channel(i);
-  }
-}
-
-// Calculates force sensor value.
-void calculate_force_voltage()
-{
-  #ifdef USE_LOAD_CELL
-    analog_voltage_readings[FORCE_VALUE_INDEX] = adc_read_channel(LC_ADC);
-  #else
-    analog_voltage_readings[FORCE_VALUE_INDEX] = adc_read_channel(F_ADC); 
-  #endif
-}
-
-// Report the version of the board based on the revision voltage divider
-void report_revision()
-{
-  analog_voltage_readings[REV_VALUE_INDEX] = adc_read_channel(RD_ADC);
-}
-
 
  // Prints real-time data. This function grabs a real-time snapshot of the stepper subprogram
  // and the actual location of the CNC machine. Users may change the following function to their

--- a/report.h
+++ b/report.h
@@ -97,13 +97,6 @@ void calculate_motor_voltage();
 void calculate_force_voltage();
 void report_revision();
 
-// Variable for holding voltage value after ADC
-
-uint16_t analog_voltage_readings[VOLTAGE_SENSOR_COUNT];
-
-#define FORCE_VALUE_INDEX 4 // Index of analog_voltage_readings that holds force value
-#define REV_VALUE_INDEX 5
-
 // Prints recorded probe position
 void report_probe_parameters(uint8_t error);
 

--- a/signals.c
+++ b/signals.c
@@ -1,0 +1,70 @@
+/*
+  Not part of Grbl. KeyMe specific.
+  
+  Signal is one layer of abstraction above adc.h and adc.c.
+
+  ADC values are read in specific time intervals, filtered and
+  stored in the appropriate arrays.
+*/
+
+#include "signals.h"
+#include "adc.h"
+#include "systick.h"
+
+#define N_FILTER 3
+#define SIGNALS_CALLBACK_INTERVAL 20 
+#define x(i) analog_voltage_readings_x[FORCE_VALUE_INDEX][i]
+
+uint16_t analog_voltage_readings_x[VOLTAGE_SENSOR_COUNT][N_FILTER + 1];  // Unfiltered ADC readings
+
+// Updates motors ADC readings
+void signals_update_motors()
+{
+  uint8_t idx;
+
+  for (idx = 0; idx < N_AXIS; idx++) {
+    // Assumes the motors are on ADC channels 0-3 and in the same
+    // order in analog_voltage_readings. If the pins are changed, a
+    // motors should be mapped to ADC channels.
+    analog_voltage_readings[idx] = adc_read_channel(idx);
+  }
+}
+
+// Filter and update force ADC reading
+void signals_update_force()
+{
+  #ifdef USE_LOAD_CELL
+    x(N_FILTER) = adc_read_channel(LC_ADC);
+  #else
+    x(N_FILTER) = adc_read_channel(F_ADC); 
+  #endif
+    /*
+    Filter:
+      Moving average Hanning Filter:
+      y[k] = 0.25 * (x[k] + 2x[k-1] + x[k-2])
+    */
+    analog_voltage_readings[FORCE_VALUE_INDEX] = (uint16_t)(
+    (x(N_FILTER) + (x(N_FILTER - 1) << 1) + x(N_FILTER - 2)) >> 2);
+
+    // Advance all values in the unfiltered array
+    memmove(&x(0), &x(1) ,sizeof(uint16_t) * N_FILTER-1);
+ 
+}
+
+void signals_callback()
+{
+  signals_update_motors();
+  signals_update_force();
+ 
+  // Register callback to this function in SIGNALS_CALLBACK_INTERVAL milliseconds
+  systick_register_callback(SIGNALS_CALLBACK_INTERVAL, signals_callback);
+}
+
+// Read value from revision voltage divider
+// No nead to filter since the value is constant.
+// Only needs to be called once during initialization
+void signals_update_revision()
+{
+  analog_voltage_readings[REV_VALUE_INDEX] = adc_read_channel(RD_ADC);
+}
+

--- a/signals.h
+++ b/signals.h
@@ -1,0 +1,25 @@
+/*
+  Not part of Grbl. KeyMe specific.
+  
+  Signal is one layer of abstraction above adc.h and adc.c.
+
+  ADC values are read in specific time intervals, filtered and
+  stored in the appropriate arrays.
+*/
+
+#ifndef signals_h
+#define signals_h
+
+#include "system.h"
+
+#define FORCE_VALUE_INDEX 4  // Index of force value in analog_voltage_readings
+#define REV_VALUE_INDEX 5  // Index of revision value in analog_voltage_readings
+
+// Array of latest ADC readings
+uint16_t analog_voltage_readings[VOLTAGE_SENSOR_COUNT];  // Filtered ADC readings
+
+void signals_update_revision(); // Called from main.c
+void signals_callback();        // Callback first registered in main.c
+
+#endif
+

--- a/stepper.c
+++ b/stepper.c
@@ -29,7 +29,7 @@
 #include "motion_control.h"
 #include "report.h"
 #include "magazine.h"
-
+#include "signals.h"
 #include "spi.h"
 
 // Some useful constants.
@@ -74,7 +74,7 @@ static const uint8_t stepper_init_registers[4][18] = {
   },
   {
     //YTABLE
-    0x0C, 0x11, // CTRL,   DTIME=11, ISGAIN=00, EXSTALL=0, MODE=0010, RSTEP=0, RDIR=0, ENBL=1	
+    0x0C, 0x11, // CTRL,   DTIME=11, ISGAIN=00, EXSTALL=0, MODE=0010, RSTEP=0, RDIR=0, ENBL=1  
     0x11, 0xFF, // TORQUE, SMPLTH=001, TORQUE=0xFF
     0x20, 0x30, // OFF,    PWMMODE=0, TOFF=0x30
     0x30, 0x80, // BLANK,  ABT=0, TBLANK=0x80
@@ -1226,3 +1226,4 @@ void st_prep_buffer()
      we know when the plan is feasible in the context of what's already in the code and not
      require too much more code?
 */
+

--- a/system.c
+++ b/system.c
@@ -154,10 +154,10 @@ void system_execute_startup(char *line)
     } else {
       if (line[0] != 0) {
         printString(line); // Echo startup line to indicate execution.
-	uint8_t status = gc_execute_line(line);
-	if (status) {
-	  report_status_message(status);
-	}
+        uint8_t status = gc_execute_line(line);
+        if (status) {
+          report_status_message(status);
+        }
       }
     }
   }
@@ -418,3 +418,4 @@ linenumber_t linenumber_peek(){
   }
   return 0;
 }
+

--- a/systick.c
+++ b/systick.c
@@ -1,0 +1,106 @@
+/*
+  Not part of Grbl. KeyMe specific.
+
+  System tick implementation. Global sys_tick value is updated.
+  Callbacks can be registed to be called after a certain time.
+
+  sys_tick uses Timer1. Timer1 should not be used anywhere else.
+
+*/
+#include "systick.h"
+#include "nuts_bolts.h"
+
+#define MAX_CALLBACKS 32
+
+callback_t systick_callbacks_array[MAX_CALLBACKS];
+uint8_t systick_len;  // Length of callback array 
+
+// Helper function for qsort. Used in systick_sort_callback_array
+int cmp(const void * a, const void * b)
+{
+  callback_t *cb_a = (callback_t *)a;
+  callback_t *cb_b = (callback_t *)b;
+  
+  return (cb_a->callback_time - cb_b->callback_time);
+
+}
+
+// Sort the callback array according to lowest callback time
+void systick_sort_callback_array()
+{
+  qsort(systick_callbacks_array, systick_len, sizeof(callback_t), cmp); 
+}
+
+void systick_service_callbacks()
+{
+  if (!systick_len) {
+    return;
+  }
+
+  // Sort the callback array
+  systick_sort_callback_array();
+  
+  // Count the number of expired callbacks
+  uint8_t idx = 0;
+  while (systick_callbacks_array[idx].callback_time <= sys_tick) {
+    idx++;
+  }
+  
+  while (idx > 0) {
+    // Call the callback function
+    systick_callbacks_array[0].cb_function();
+
+    // Shift all entries in the callback array to the left and decrement the index
+    memmove(&systick_callbacks_array[0], &systick_callbacks_array[1], sizeof(callback_t) * (--systick_len));
+    idx--;
+  }
+}
+
+void systick_init()
+{
+  // Reset sys_tick
+  sys_tick = 0;
+
+  TCCR1B |= (1 << CS11) | (1 << CS10); // Prescaler 64x - 16 MHz / 64 = 250 kHz
+
+  // CTC mode - Clear Timer on Compare
+  bit_true(TCCR1B, 1 << WGM12);
+  
+  // Inialize the counter
+  TCNT1 = 0;
+  
+  // Initialize timer compare value
+  OCR1A = 250; // 250 kHz/250 = 1 kHz, hence, sys_tick will tick every ms 
+  
+  // Enable the compare interrupt in Timer Interrupt Mask Register
+  bit_true(TIMSK1, 1 << OCIE1A);
+
+  // Initialize length of the callback array
+  systick_len = 0; 
+
+}
+
+// Every millisecond
+ISR(TIMER1_COMPA_vect)
+{
+  TCNT1 = 0;
+  sys_tick++;
+}
+
+// Schedule a callback
+void systick_register_callback(uint32_t ms_later, void (*func)())
+{
+ 
+  uint64_t callback_time = sys_tick + ms_later;
+
+  callback_t to_insert;
+  to_insert.callback_time = callback_time;
+  to_insert.cb_function = func;
+
+  // Insert callback into callbacks array
+  systick_callbacks_array[systick_len] = to_insert;
+
+  // Increase the length of the array
+  systick_len++; 
+
+}

--- a/systick.h
+++ b/systick.h
@@ -1,0 +1,29 @@
+/*
+  Not part of Grbl. KeyMe specific.
+ 
+  System tick implementation. Global sys_tick value is updated.
+  Callbacks can be registed to be called after a certain time.
+  
+  sys_tick uses Timer1. Timer1 should not be used anywhere else.
+ 
+*/
+
+#ifndef __SYSTICK_H
+#define __SYSTICK_H
+
+#include "system.h"
+
+typedef struct {
+  uint64_t callback_time;
+  void (*cb_function)();
+} callback_t;
+
+uint64_t sys_tick;
+
+void systick_init();
+
+void systick_register_callback(uint32_t, void(*)());
+
+void systick_service_callbacks();
+
+#endif


### PR DESCRIPTION
The goal of this change is to enable us to do more sophisticated filtering on our ADCs in order to have a stable force sensing feedback loop while gripping keys before bumping them. This also paves the way for using ADC readings for more than just reporting the raw values. Furthermore, the use of SysTick and SysTick callbacks reaches beyond ADC readings.  

The main changes are:
- Implement a SysTick timer with callbacks
- Add a layer of abstraction between the ADC driver and the functions that need access to the ADC readings
- Add basic moving average filtering to the force ADC readings

**SysTick timer with callbacks:**
In order to do filtering on the ADCs, the ADC channels need to be read at a constant rate. To do so, a timer interrupt can be used. However, the micro-contoller that we are using only has 5 timers and we might want to implement more timed events in the future.

So, instead of dedicating a timer just to periodically read the ADC values, a system tick was implemented. Every millisecond SysTick gets increased. A SysTick callback can be registered. The callback function passed is then called in the specified time.

The SysTick callbacks are checked and called in the protocol main loop in protocol.c and not in the SysTick ISR. Therefore, these callbacks happen in soft realtime.

**ADC abstraction layer**
Before this change, ADC values were read directly from the ADC registers and reported over serial in reports.c. This happened whenever a "|" command was received over serial.

Now, another layer was added to make filtering easier and to allow other functions to access _filtered_ ADC readings from global ADC arrays.

**Filtering**
A basic moving average filter was added to the force ADC readings. Modifying or adding filters in signals.c will be very simple in the future.
