### PR TITLE
Add ADC filter, force servoing, systick callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PORT       ?= /dev/ttyUSB0
 PROGRAMMER ?= -c wiring -P $(PORT) -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o coolant_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
-             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o spi.o
+             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o spi.o signals.o systick.o
 
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m

--- a/adc.h
+++ b/adc.h
@@ -1,14 +1,21 @@
 /*
-  Not part of Grbl, written by KeyMe
+  Not part of Grbl. KeyMe specific
 */
 
 #ifndef adc_h
 #define adc_h
 
+typedef enum {
+  X = 0,
+  Y,
+  Z,
+  C,
+  FORCE,
+  REV
+} channel_t;
+
+uint16_t raw_adc_readings[VOLTAGE_SENSOR_COUNT];
+
 void adc_init();
-
-uint16_t adc_read_channel(uint8_t channel);
-
-
 
 #endif

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -52,7 +52,7 @@
 #define C_DIRECTION_BIT   7 // Atmega2560 pin 27 / Arduino Digital Pin xx
 #define DIRECTION_MASK ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)|(1<<C_DIRECTION_BIT)) // All direction bits
 
-          // Define stepper driver enable/disable output pin.
+// Define stepper driver enable/disable output pin.
 #define STEPPERS_DISABLE_DDR   DDRJ
 #define STEPPERS_DISABLE_PORT  PORTJ
 #define X_DISABLE_BIT 2  // J2 / Atmega Pin 65

--- a/limits.h
+++ b/limits.h
@@ -26,16 +26,18 @@
 // This is defined by the largest homing flag in the system. The Y flag is
 // the largest with a length of just under 40 mm.
 #define MAXFLAGLEN 40.0
-// Travel distance for the gripper from home is around 12 mm. Travel distane for gripping key is usually around 2-3 mm.
+
+// Travel distance for the gripper from home is around 12 mm.
+// Travel distane for gripping key is usually around 2-3 mm.
 #define MAXSERVODIST 12.0
-#define AXISLOCKSERVO 0x4
 
 typedef struct {
   uint8_t expected;
   uint8_t active;
   volatile uint8_t ishoming;
   volatile uint8_t isservoing;
-  uint8_t mag_gap_check; //keyme specific
+  uint8_t mag_gap_check;  // KeyMe specific
+  uint16_t bump_grip_force;  // KeyMe specific: Value must be 0-1023
 } limit_t;
 
 extern limit_t limits;
@@ -56,5 +58,4 @@ void limits_soft_check(float *target);
 
 // Perform force servo cycle
 void limits_force_servo();
-float travel_servo;
 #endif

--- a/main.c
+++ b/main.c
@@ -37,11 +37,12 @@
 #include "progman.h"
 #include "adc.h"
 #include "spi.h"
+#include "systick.h"
+#include "signals.h"
 
 // Declare system global variable structure
 system_t sys;
 volatile sys_flags_t sysflags;
-
 
 int main(void)
 {
@@ -51,10 +52,11 @@ int main(void)
     spi_init();      // Setup SPI Control register and pins
   #endif
 
+
   settings_init(); // Load grbl settings from EEPROM
   stepper_init();  // Configure stepper pins and interrupt timers
   system_init();   // Configure pinout pins and pin-change interrupt
-  counters_init(); //configure encoder and counter interrupt.
+  counters_init(); // Configure encoder and counter interrupt.
   adc_init();
 
   memset(&sys, 0, sizeof(sys));  // Clear all system variables
@@ -94,8 +96,11 @@ int main(void)
     plan_reset(); // Clear block buffer and planner variables
     st_reset(); // Clear stepper subsystem variables.
     progman_init();
-    report_revision(); // ADC - read revision voltage form revision voltage divider  
-  
+    signals_init();
+    systick_init();  // Init systick and systick callbacks
+
+    // Register first signals update callback
+    systick_register_callback(500, signals_callback); // Start polling ADCs 0.5 seconds after init
 
     // Sync cleared gcode and planner positions to current system position.
     plan_sync_position();

--- a/motion_control.c
+++ b/motion_control.c
@@ -248,7 +248,7 @@ void mc_homing_cycle(uint8_t axis_mask)
   limits_configure();
 }
 
-// Wrapper function for force servoing. This mimics the homing cycle.
+// Wrapper function for limits_force_servo. This mimics the homing cycle.
 void mc_force_servo_cycle()
 {
   sys.state = STATE_FORCESERVO; // Set system state variable
@@ -256,8 +256,14 @@ void mc_force_servo_cycle()
     
   // Perform force servoing.
   limits_force_servo();
+  
   protocol_execute_runtime(); // Check for reset and set system abort.
-  if (sys.abort) { return; } // Did not complete. Alarm state set by mc_alarm.
+  
+  // Did not complete. Alarm state set by mc_alarm.
+  if (sys.abort) { 
+    return; 
+  }
+
   // Force Servoing Complete! Setup system for normal operation.
 
   // Gcode parser position was circumvented by the limits_force_servo() routine, so sync position now.

--- a/report.c
+++ b/report.c
@@ -37,8 +37,8 @@
 #include "stepper.h"
 #include "counters.h"
 #include "probe.h"
-#include "adc.h"
 #include "magazine.h"
+#include "signals.h"
 
 // Handles the primary confirmation protocol response for streaming interfaces and human-feedback.
 // For every incoming line, this method responds with an 'ok' for a successful command or an
@@ -390,10 +390,9 @@ void report_counters()
 void report_voltage()
 {
   uint8_t i;
-  calculate_motor_voltage();
   printPgmString( PSTR("|") );
   for (i = 0; i < VOLTAGE_SENSOR_COUNT; i++) {
-    printInteger((uint32_t)analog_voltage_readings[i]);
+    printInteger((uint32_t)signals.adc_samples[i]);
     if (i < VOLTAGE_SENSOR_COUNT - 1)
       printPgmString(PSTR(","));
   }
@@ -411,40 +410,11 @@ void report_magazine_slop()
   printPgmString(PSTR("\r\n"));
 }
 
-// Calculates voltage at motors. Only called in report_voltage().
-void calculate_motor_voltage(){
-  uint8_t i;
-
-  for (i = 0; i < N_AXIS; i++) {
-    // Assumes the motors are on ADC channels 0-3 and in the same
-    // order in analog_voltage_readings If the pins are changed, a
-    // map should be made to motors to ADC channels.
-    analog_voltage_readings[i] = adc_read_channel(i);
-  }
-}
-
-// Calculates force sensor value.
-void calculate_force_voltage()
-{
-  #ifdef USE_LOAD_CELL
-    analog_voltage_readings[FORCE_VALUE_INDEX] = adc_read_channel(LC_ADC);
-  #else
-    analog_voltage_readings[FORCE_VALUE_INDEX] = adc_read_channel(F_ADC); 
-  #endif
-}
-
-// Report the version of the board based on the revision voltage divider
-void report_revision()
-{
-  analog_voltage_readings[REV_VALUE_INDEX] = adc_read_channel(RD_ADC);
-}
-
-
- // Prints real-time data. This function grabs a real-time snapshot of the stepper subprogram
- // and the actual location of the CNC machine. Users may change the following function to their
- // specific needs, but the desired real-time data report must be as short as possible. This is
- // requires as it minimizes the computational overhead and allows grbl to keep running smoothly,
- // especially during g-code programs with fast, short line segments and high frequency reports (5-20Hz).
+// Prints real-time data. This function grabs a real-time snapshot of the stepper subprogram
+// and the actual location of the CNC machine. Users may change the following function to their
+// specific needs, but the desired real-time data report must be as short as possible. This is
+// requires as it minimizes the computational overhead and allows grbl to keep running smoothly,
+// especially during g-code programs with fast, short line segments and high frequency reports (5-20Hz).
 uint8_t report_realtime_status()
 {
   // **Under construction** Bare-bones status report. Provides real-time machine position relative to

--- a/report.h
+++ b/report.h
@@ -100,16 +100,8 @@ void report_revision();
 // Reporting of magazine slop
 void report_magazine_slop();
 
-// Variable for holding voltage value after ADC
-
-uint16_t analog_voltage_readings[VOLTAGE_SENSOR_COUNT];
-
-#define FORCE_VALUE_INDEX 4 // Index of analog_voltage_readings that holds force value
-#define REV_VALUE_INDEX 5
-
 // Prints recorded probe position
 void report_probe_parameters(uint8_t error);
-
 
 // Prints a message indicating probe failure
 void report_probe_fail();

--- a/signals.c
+++ b/signals.c
@@ -1,0 +1,99 @@
+/*
+  Not part of Grbl. KeyMe specific.
+  
+  Signal is one layer of abstraction above adc.h and adc.c.
+
+  ADC values are read in specific time intervals, filtered and
+  stored in the appropriate arrays.
+*/
+
+#include "signals.h"
+#include "adc.h"
+#include "systick.h"
+
+#define N_FILTER 3
+#define SIGNALS_DEFAULT_INTERVAL 1000 
+#define X_BUF(i) adc_samples_x[FORCE_VALUE_INDEX][i]
+
+// Unfiltered ADC readings
+int16_t adc_samples_x[VOLTAGE_SENSOR_COUNT][N_FILTER]; 
+
+void signals_init()
+{
+  signals.pause = 0;
+  signals.callback_period = SIGNALS_DEFAULT_INTERVAL;
+  signals.force_offset = 0;
+}
+
+// Update motors ADC readings
+void signals_update_motors()
+{
+  uint8_t idx;
+
+  for (idx = 0; idx < N_AXIS; idx++) {
+    // Assumes the motors are on ADC channels 0-3 and in the same
+    // order in signals.adc_samples. If the pins are changed, a
+    // motors should be mapped to ADC channels.
+    signals.adc_samples[idx] = raw_adc_readings[idx];
+  }
+}
+
+// Filter and update force ADC reading
+void signals_update_force()
+{
+  // Since the raw adc value changes based on an interrupt,
+  // copy the raw value at the beginning of this function to
+  // ensure that the value being used doesn't change during 
+  // during the function call.
+  uint16_t raw_value = raw_adc_readings[FORCE];
+  
+  // Index in signal buffer
+  static const uint8_t n = N_FILTER - 1;
+
+  // Make sure that the offset doesn't make the sample negative.
+  if (signals.force_offset > raw_value) {
+    X_BUF(n) = 0;
+  } else {
+    X_BUF(n) = raw_value - signals.force_offset;
+  }
+
+  /*
+    Filter:
+      Moving average Hanning Filter:
+      y[k] = 0.25 * (x[k] + 2x[k-1] + x[k-2])
+  */
+  signals.adc_samples[FORCE_VALUE_INDEX] = (uint16_t)(
+  (X_BUF(n) + (X_BUF(n - 1) << 1) + X_BUF(n - 2)) >> 2);
+
+  // Advance all values in the unfiltered array
+  memmove(&X_BUF(0), &X_BUF(1) ,sizeof(uint16_t) * N_FILTER - 1);
+   
+}
+
+void signals_callback()
+{
+  signals_update_motors();
+  signals_update_revision();
+
+  if (signals.pause) {
+    // signals.pause needs to be set before the force servoing cycle
+    // is started to prevent the signals_callback from asynchronously
+    // updating the force value while force servoing.
+    systick_register_callback(signals.callback_period, signals_callback);
+    return;
+  }  
+
+  signals_update_force();
+ 
+  // Register callback to this function in SIGNALS_CALLBACK_INTERVAL milliseconds
+  systick_register_callback(signals.callback_period, signals_callback);
+}
+
+// Read value from revision voltage divider
+// No nead to filter since the value is constant.
+// Only needs to be called once during initialization
+void signals_update_revision()
+{
+  signals.adc_samples[REV_VALUE_INDEX] = raw_adc_readings[REV];
+}
+

--- a/signals.h
+++ b/signals.h
@@ -1,0 +1,36 @@
+/*
+  Not part of Grbl. KeyMe specific.
+  
+  Signal is one layer of abstraction above adc.h and adc.c.
+
+  ADC values are read in specific time intervals, filtered and
+  stored in the appropriate arrays.
+*/
+
+#ifndef signals_h
+#define signals_h
+
+#include "system.h"
+
+#define FORCE_VALUE_INDEX 4  // Index of force value in signals.adc_samples
+#define REV_VALUE_INDEX 5  // Index of revision value in signals.adc_samples
+
+// Alias the force reading since it is often used throughout the code
+#define FORCE_VAL signals.adc_samples[FORCE_VALUE_INDEX]
+
+typedef struct {
+  uint8_t pause;  // Pause the reading of ADC values periodically with a callback
+  uint16_t adc_samples[VOLTAGE_SENSOR_COUNT];  // Filtered ADC readings
+  uint16_t callback_period;  // Period between ADC readings TODO: Add command to change this over serial  
+  uint8_t force_offset;
+} signals_t;
+signals_t signals;
+
+void signals_init();
+void signals_update_revision(); // Called from main.c
+void signals_update_motors();
+void signals_update_force();
+void signals_callback(); // Callback first registered in main.c
+
+#endif
+

--- a/stepper.h
+++ b/stepper.h
@@ -26,7 +26,7 @@
   #define SEGMENT_BUFFER_SIZE 6
 #endif
 
-#define GRIPPER_FORCE_THRESHOLD 5
+#define GRIPPER_FORCE_THRESHOLD 2
 
 extern float travel_servo;
 

--- a/system.h
+++ b/system.h
@@ -89,8 +89,6 @@
 #define SYSFLAG_EOL_REPORT bit(0)  // Block is done executing, report linenum
 #define SYSFLAG_AUTOSTART  bit(1)  // autostart is active
 
-uint16_t force_target_val;
-
 // Define global system variables
 typedef struct {
   uint8_t abort;                 // System abort flag. Forces exit back to main loop for reset.

--- a/systick.c
+++ b/systick.c
@@ -1,0 +1,108 @@
+/*
+  Not part of Grbl. KeyMe specific.
+
+  System tick implementation. Global sys_tick value is updated.
+  Callbacks can be registed to be called after a certain time.
+
+  sys_tick uses Timer1. Timer1 should not be used anywhere else.
+
+*/
+#include "systick.h"
+#include "nuts_bolts.h"
+
+#define MAX_CALLBACKS 32
+
+callback_t systick_callbacks_array[MAX_CALLBACKS];
+static uint8_t systick_len;  // Length of callback array 
+
+// Helper function for qsort. Used in systick_sort_callback_array
+int cmp(const void * a, const void * b)
+{
+  callback_t *cb_a = (callback_t *)a;
+  callback_t *cb_b = (callback_t *)b;
+  
+  return (cb_a->callback_time - cb_b->callback_time);
+
+}
+
+// Sort the callback array according to lowest callback time
+void systick_sort_callback_array()
+{
+  qsort(systick_callbacks_array, systick_len, sizeof(callback_t), cmp); 
+}
+
+void systick_service_callbacks()
+{
+  if (!systick_len) {
+    return;
+  }
+
+  // Sort the callback array
+  systick_sort_callback_array();
+  
+  // Count the number of expired callbacks
+  uint8_t idx = 0;
+
+  while (systick_callbacks_array[idx].callback_time <= sys_tick && idx < systick_len) {
+    idx++;
+  }
+  
+  while (idx > 0) {
+    // Call the callback function
+    systick_callbacks_array[0].cb_function();
+
+    // Shift all entries in the callback array to the left and decrement the index
+    memmove(&systick_callbacks_array[0], &systick_callbacks_array[1], sizeof(callback_t) * (systick_len - idx));
+    systick_len--;
+    idx--;
+  }
+}
+
+void systick_init()
+{
+  // Reset sys_tick
+  sys_tick = 0;
+
+  TCCR1B |= (1 << CS11) | (1 << CS10); // Prescaler 64x - 16 MHz / 64 = 250 kHz
+
+  // CTC mode - Clear Timer on Compare
+  bit_true(TCCR1B, 1 << WGM12);
+  
+  // Inialize the counter
+  TCNT1 = 0;
+  
+  // Initialize timer compare value
+  OCR1A = 250; // 250 kHz/250 = 1 kHz, hence, sys_tick will tick every ms 
+  
+  // Enable the compare interrupt in Timer Interrupt Mask Register
+  bit_true(TIMSK1, 1 << OCIE1A);
+
+  // Initialize length of the callback array
+  systick_len = 0; 
+
+}
+
+// Every millisecond
+ISR(TIMER1_COMPA_vect)
+{
+  TCNT1 = 0;
+  sys_tick++;
+}
+
+// Schedule a callback
+void systick_register_callback(uint32_t ms_later, void (*func)())
+{
+ 
+  uint64_t callback_time = sys_tick + ms_later;
+
+  callback_t to_insert;
+  to_insert.callback_time = callback_time;
+  to_insert.cb_function = func;
+
+  // Insert callback into callbacks array
+  systick_callbacks_array[systick_len] = to_insert;
+
+  // Increase the length of the callback array
+  systick_len++; 
+
+}

--- a/systick.h
+++ b/systick.h
@@ -1,0 +1,26 @@
+/*
+  Not part of Grbl. KeyMe specific.
+ 
+  System tick implementation. Global sys_tick value is updated.
+  Callbacks can be registed to be called after a certain time.
+  
+  sys_tick uses Timer1. Timer1 should not be used anywhere else.
+ 
+*/
+
+#ifndef __SYSTICK_H
+#define __SYSTICK_H
+
+#include "system.h"
+
+typedef struct {
+  uint64_t callback_time;
+  void (*cb_function)();
+} callback_t;
+
+uint64_t sys_tick;
+void systick_init();
+void systick_register_callback(uint32_t, void(*)());
+void systick_service_callbacks();
+
+#endif


### PR DESCRIPTION
This PR replaces https://github.com/keyme/grbl/pull/56.

In addition to the changes mention in https://github.com/keyme/grbl/pull/56, the following updates are implemented:

* Raw ADC values are continuously read, and not only when we sample them at specific intervals. This is done by cycling through channels and storing values in a raw data array when the ADC conversion completed interrupt is triggered. This allows us to sample raw ADC data without waiting for ADC conversion.
* Force servoing while gripping. 
* Serial command to set load cell offset - this is required by the load cell calibration procedure.
