### PR TITLE
Add ability to probe specified sensor on any axis

### DIFF
--- a/limits.c
+++ b/limits.c
@@ -116,7 +116,6 @@ void limits_update_homing_values(uint8_t cycle_mask, float * homing_rate, float 
 // Called from limits_go_home
 void limits_plan_homing(uint8_t cycle_mask, float homing_rate, float max_travel, uint8_t axislock, uint8_t approach, float* target, uint8_t flipped)
 {
- 
   uint8_t idx;
   
   // Set target location and rate for active axes.
@@ -124,6 +123,7 @@ void limits_plan_homing(uint8_t cycle_mask, float homing_rate, float max_travel,
 
   // limit travel distance to the length of the largest flag
   float travel = approach ? max_travel : MAXFLAGLEN;
+
   // set target for moving axes based on direction
   for (idx = 0; idx < N_AXIS; idx++) {
     if (bit_istrue(cycle_mask, bit(idx))) {
@@ -376,8 +376,6 @@ void limits_plan_force_servo(float servo_rate)
 
   st_prep_buffer(); // Prep and fill segment buffer from newly planned block.
   st_wake_up(); // Initiate motion
-
-
 }
 
 // Move gripper to limits.bump_grip_force.

--- a/motion_control.c
+++ b/motion_control.c
@@ -352,11 +352,12 @@ void mc_reset()
     spindle_stop();
     coolant_stop();
 
-    // Kill steppers only if in any motion state, i.e. cycle, feed hold, homing, or jogging
+    // Kill steppers only if in any motion state, i.e. cycle, feed hold,
+    // homing, force servoing, probing or jogging.
     // NOTE: If steppers are kept enabled via the step idle delay setting, this also keeps
     // the steppers enabled by avoiding the go_idle call altogether, unless the motion state is
     // violated, by which, all bets are off.
-    if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING | STATE_FORCESERVO)) {
+    if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING | STATE_FORCESERVO | STATE_PROBING)) {
       sys.alarm |= ALARM_ABORT_CYCLE;  //killed while in motion
       SYS_EXEC |= EXEC_ALARM; // Flag main program to execute alarm state.
       st_go_idle(); // Force kill steppers. Position has likely been lost.

--- a/nuts_bolts.h
+++ b/nuts_bolts.h
@@ -25,11 +25,13 @@
 #define false 0
 #define true 1
 
-#define N_AXIS 4 // Number of axes
-#define X_AXIS 0 // Axis indexing value. Must start with 0 and be continuous.
-#define Y_AXIS 1
-#define Z_AXIS 2
-#define C_AXIS 3
+enum e_axis {
+  X_AXIS = 0,
+  Y_AXIS,
+  Z_AXIS,
+  C_AXIS,
+  N_AXIS
+};
 
 #define MM_PER_INCH (25.40)
 #define INCH_PER_MM (0.0393701)

--- a/probe.c
+++ b/probe.c
@@ -21,13 +21,143 @@
 #include "system.h"
 #include "probe.h"
 #include "counters.h"
+#include "protocol.h"
+#include "stepper.h"
+#include "planner.h"
+#include "settings.h"
+#include "limits.h"
+#include "gcode.h"
+
+struct probe_state probe;
+
+// Idx, Mask, PIN - Note PIN is not the
+// pin of the microcontroller, but Port In.
+static struct {
+  uint8_t idx;
+  uint8_t mask;
+  volatile uint8_t *in_port;
+} sensor_map[] = {
+  {
+    .idx = MAG_SENSOR,
+    .mask = MAGAZINE_ALIGNMENT_MASK,
+    .in_port = &MAGAZINE_ALIGNMENT_PIN
+  }
+};
 
 // Probe pin initialization routine.
 void probe_init() 
 {
-  PROBE_DDR &= ~(PROBE_MASK); // Configure as input pins
-  PROBE_PORT |= PROBE_MASK;   // Enable internal pull-up resistors. Normal high operation.
+  // Configure as input pins
+  MAGAZINE_ALIGNMENT_DDR &= ~(MAGAZINE_ALIGNMENT_MASK);
 
+  // Enable internal pull-up resistors. Normal high operation.
+  MAGAZINE_ALIGNMENT_PORT |= MAGAZINE_ALIGNMENT_MASK;
+
+  probe.active_sensor = E_SENSOR_TYPES;
+  probe.probe_reached = 0;
+  probe.isprobing = 0;
+
+}
+
+void probe_check()
+{
+  if (probe_get_active_sensor_state())
+    probe.isprobing = 0;
+}
+
+void probe_plan_move(uint8_t sensor, uint8_t axis, uint8_t dir)
+{
+  /*  sensor - Which sensor to home
+   *  axis - Which axis to move to the sensor
+   *  dir - true = neg; false = pos
+   */
+
+  // Set the active probe
+  probe.active_sensor = sensor;
+
+  // Approach has all bits set (neg dir) or none (pos dir)
+  const uint8_t approach = dir ? ~0 : 0;
+
+  // Limit travel distance to the max flag
+  const float travel = settings.max_travel[axis];
+  const uint8_t flipped = settings.homing_dir_mask >> X_DIRECTION_BIT;  //assumes keyme configuration.
+ 
+  // Set target for axis
+  float target[N_AXIS] = {0};
+  target[axis] = ((flipped & (1 << axis)) ^ approach) ? -travel : travel;
+
+  // Set speed
+  //TODO: Allow for this rate to be set over serial / passed as a variable
+  const float probe_rate = settings.homing_seek_rate[axis];
+
+  // Reset plan and stepper buffers
+  plan_reset();
+  st_reset();
+
+  // Plan moition. Planner buffer should be empty, bypass mc_line() 
+  plan_buffer_line(target, probe_rate, false, LINENUMBER_EMPTY_BLOCK); 
+
+  // Tell the system we are probing
+  probe.isprobing = 1;
+
+  // Enable hard limit checking
+  limits_enable(LIMIT_MASK & HARDSTOP_MASK, 0);
+
+
+}
+
+void probe_loop()
+{
+  // Start stepper
+  st_prep_buffer();
+  st_wake_up();
+
+  while (probe.isprobing) {
+    // Check for user reset and allow
+    // protocol_execute_runtime to run in this loop 
+    protocol_execute_runtime();
+    
+    if (SYS_EXEC & EXEC_RESET) {
+      protocol_execute_runtime();
+      return;
+    } 
+
+    if (ESTOP_PIN & ESTOP_MASK) {
+      sys.alarm |= ALARM_ESTOP;
+      SYS_EXEC |= (EXEC_FEED_HOLD | EXEC_ALARM | EXEC_CRIT_EVENT);
+      protocol_execute_runtime();
+      return;
+    }
+
+    // Check if we never reach probe.
+    if ((SYS_EXEC & EXEC_CYCLE_STOP) ) {
+      sys.alarm |= ALARM_PROBE_FAIL;
+      SYS_EXEC |= EXEC_CRIT_EVENT;
+      protocol_execute_runtime();
+      return;
+    }
+  }
+
+  // Disable limits
+  limits_disable();
+
+  // Force kill steppers and reset
+  // step segment buffer
+  st_reset();
+  plan_reset(); 
+
+}
+
+void probe_move_to_sensor(enum e_sensor sensor, enum e_axis axis, uint8_t dir)
+{
+  sys.state = STATE_PROBING;
+  probe_plan_move(sensor, axis, dir);
+  probe_loop();
+
+  gc_sync_position();
+
+  sys.state = STATE_IDLE;
+  st_go_idle();
 }
 
 // Monitors probe pin state and records the system position when detected. Called by the
@@ -41,12 +171,10 @@ void probe_state_monitor()
     memcpy(sys.probe_position, sys.position, sizeof(float)*N_AXIS);
     SYS_EXEC |= EXEC_FEED_HOLD;
   }
+
   if (ESTOP_PIN & ESTOP_MASK) {
     sys.alarm |= ALARM_ESTOP;
     SYS_EXEC |= (EXEC_FEED_HOLD|EXEC_ALARM|EXEC_CRIT_EVENT);
   }
 }
-
-
-
 

--- a/probe.h
+++ b/probe.h
@@ -17,23 +17,49 @@
   You should have received a copy of the GNU General Public License
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */
-  
+
 #ifndef probe_h
 #define probe_h 
 
+#define N_SENSORS 1
 // Values that define the probing state machine.  
 #define PROBE_OFF     0 // No probing. (Must be zero.)
 #define PROBE_ACTIVE  1 // Actively watching the input pin.
 
+enum e_sensor {
+  MAG_SENSOR = 0,
+  KEY_SENSOR,
+  E_SENSOR_TYPES
+};
+
+struct probe_state {
+  enum e_sensor active_sensor;  // The currently active probe seonsor
+  uint8_t probe_reached;  // Flag to indicate if active probe is reached
+  uint8_t isprobing;
+
+};
+
+extern struct probe_state probe;
+
 // Probe pin initialization routine.
 void probe_init();
+
+// Plan a probe move to a probe sensor on an axis in a given direction
+void probe_move_to_sensor(enum e_sensor, enum e_axis, uint8_t dir);
+
+// Called from stepper ISR - needs to be very efficient
+void probe_check();
+
+// Returns active probe state
+#define ACTIVE_SENSOR_MASK (sensor_map[probe.active_sensor].mask)
+#define ACTIVE_SENSOR_PIN (*sensor_map[probe.active_sensor].in_port)
+#define probe_get_active_sensor_state() (!(ACTIVE_SENSOR_MASK & ACTIVE_SENSOR_PIN))
 
 // Returns probe pin state. Triggered = true. Called by gcode parser and probe state monitor.
 #define probe_get_state() (!(PROBE_PIN & PROBE_MASK))
 
-
-// Monitors probe pin state and records the system position when detected. Called by the
-// stepper ISR per ISR tick.
+// Monitors probe pin state and records the system position
+// when detected. Called by the stepper ISR each ISR tick.
 void probe_state_monitor();
 
 #endif

--- a/protocol.c
+++ b/protocol.c
@@ -252,7 +252,7 @@ void protocol_execute_runtime()
 
     // Execute a cycle start by starting the stepper interrupt begin executing the blocks in queue.
     // block Start while homing/force-servoing.
-    if ((rt_exec & EXEC_CYCLE_START) && !(sys.state & STATE_HOMING) && !(sys.state & STATE_FORCESERVO)) {
+    if ((rt_exec & EXEC_CYCLE_START) && !(sys.state & (STATE_HOMING | STATE_FORCESERVO | STATE_PROBING))) {
       if (sys.state == STATE_QUEUED) {
         sys.state = STATE_CYCLE;
         st_prep_buffer(); // Initialize step segment buffer before beginning cycle.
@@ -283,9 +283,9 @@ void protocol_execute_runtime()
   // are runtime and require a direct and controlled interface to the main stepper program.
 
   // Reload step segment buffer
-  if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING | STATE_FORCESERVO))
-  { st_prep_buffer(); }
-
+  if (sys.state & (STATE_CYCLE | STATE_HOLD | STATE_HOMING | STATE_FORCESERVO | STATE_PROBING)) 
+    st_prep_buffer(); 
+  
   // Clear IO Reset bit.
   IO_RESET_PORT &= (~IO_RESET_MASK);
 

--- a/report.c
+++ b/report.c
@@ -437,6 +437,7 @@ uint8_t report_realtime_status()
     case STATE_ALARM: printPgmString(PSTR("<Alarm")); break;
     case STATE_CHECK_MODE: printPgmString(PSTR("<Check")); break;
     case STATE_FORCESERVO: printPgmString(PSTR("<Fservo")); break;
+    case STATE_PROBING: printPgmString(PSTR("<Probe:")); break;
   }
 
   // Report machine position

--- a/system.h
+++ b/system.h
@@ -40,8 +40,6 @@
 #include "cpu_map.h"
 #include "nuts_bolts.h"
 
-
-
 // Define system executor bit map. Used internally by runtime protocol as runtime command flags,
 // which notifies the main program to execute the specified runtime command asynchronously.
 // NOTE: The system executor uses an unsigned 8-bit volatile variable (8 flag limit.) The default
@@ -54,7 +52,6 @@
 #define EXEC_RESET          bit(4) // bitmask 00010000
 #define EXEC_ALARM          bit(5) // bitmask 00100000
 #define EXEC_CRIT_EVENT     bit(6) // bitmask 01000000
-//
 
 #define REQUEST_STATUS_REPORT  bit(0)
 #define REQUEST_LIMIT_REPORT   bit(1)
@@ -74,6 +71,7 @@
 #define STATE_HOLD       bit(5) // Executing feed hold
 #define STATE_FORCESERVO bit(6) // Force servo process
 #define STATE_HOME_ADJUST bit(7) // Update the minimum homing rate when some axes complete homing cycle
+#define STATE_PROBING    bit(8)
 
 // Define Grbl alarm codes. Listed most to least serious
 #define ALARM_SOFT_LIMIT  bit(0) // soft limits exceeded
@@ -92,7 +90,7 @@
 // Define global system variables
 typedef struct {
   uint8_t abort;                 // System abort flag. Forces exit back to main loop for reset.
-  uint8_t state;                 // Tracks the current state of Grbl.
+  uint16_t state;                 // Tracks the current state of Grbl.
   uint8_t flags;                 // see SYSFLAG_xxx above
   uint8_t alarm;                 // see ALARM_xxx above. which alarm(s) are active
   int32_t position[N_AXIS];      // Real-time machine (aka home) position vector in steps.


### PR DESCRIPTION
This PR allows us to probe any sensor on any axis is any direction with the serial command:
$A{AXIS},{SENSOR},{DIRECTION}

For example, the command
$AY,0,1

Will move axis Y in the negative direction until sensor 0 is reached. Right now, we only have one probe sensor, but this code lays the groundwork for adding more sensors. Hard limits are also enabled when an axis is moving.

In a future PR, the current magazine monitor probing code will be replaced to make use of this code. 