### PR TITLE
Fix probe command to work with existing motion

### DIFF
--- a/magazine.c
+++ b/magazine.c
@@ -34,12 +34,6 @@ static struct {
 
 void magazine_init()
 {
-  // Configure as input pin
-  MAGAZINE_ALIGNMENT_DDR &= ~(MAGAZINE_ALIGNMENT_MASK);
-
-  // Enable internal pull-up resistors. Normal high operation
-  MAGAZINE_ALIGNMENT_PORT |= MAGAZINE_ALIGNMENT_MASK;
-
   // Set the magazine alignment position to the current position
   memcpy(sys.probe_position, sys.position, sizeof(int32_t) * N_AXIS);
 
@@ -131,7 +125,6 @@ void magazine_loss_detector(const uint8_t magazine_alignment_on)
 
 }
 
-//KeyMe function
 // Monitors the gap in units between mags and throws an alarm if the gap is larger than a
 // specified threshold. Additionally, magazine slop can be calculated
 // if turned on via compiler flag

--- a/magazine.h
+++ b/magazine.h
@@ -1,5 +1,5 @@
 /*
-  Not part of Grbl. Written by KeyMe.
+  Not part of Grbl. KeyMe specific.
 */
 
 #ifndef magazine_h

--- a/probe.h
+++ b/probe.h
@@ -34,9 +34,9 @@ enum e_sensor {
 
 struct probe_state {
   enum e_sensor active_sensor;  // The currently active probe seonsor
-  uint8_t probe_reached;  // Flag to indicate if active probe is reached
+  volatile uint8_t probe_reached;  // Flag to indicate if active probe is reached
   uint8_t isprobing;
-
+  volatile uint8_t carousel_probe_state;
 };
 
 extern struct probe_state probe;
@@ -45,7 +45,11 @@ extern struct probe_state probe;
 void probe_init();
 
 // Plan a probe move to a probe sensor on an axis in a given direction
-void probe_move_to_sensor(enum e_sensor, enum e_axis, uint8_t dir);
+void probe_move_to_sensor(float * target, float feed_rate, uint8_t invert_feed_rate,
+  linenumber_t line_number, enum e_sensor sensor);
+
+// Used to set active probe to look for
+void set_active_probe(enum e_sensor sensor);
 
 // Called from stepper ISR - needs to be very efficient
 void probe_check();
@@ -56,10 +60,12 @@ void probe_check();
 #define probe_get_active_sensor_state() (!(ACTIVE_SENSOR_MASK & ACTIVE_SENSOR_PIN))
 
 // Returns probe pin state. Triggered = true. Called by gcode parser and probe state monitor.
-#define probe_get_state() (!(PROBE_PIN & PROBE_MASK))
+#define probe_get_carousel_state() (!(PROBE_PIN & PROBE_MASK))
 
-// Monitors probe pin state and records the system position
+// Monitors ACTIVE probe pin state and records the system position
 // when detected. Called by the stepper ISR each ISR tick.
 void probe_state_monitor();
 
+// Monitors CAROUSEL probe pin state
+void probe_carousel_monitor();
 #endif

--- a/report.c
+++ b/report.c
@@ -492,7 +492,7 @@ void report_limit_pins()
   }
   printPgmString(PSTR("/"));
   printInteger((ESTOP_PIN>>ESTOP_BIT)&1);
-  printInteger(probe_get_state()?1:0);
+  printInteger(probe_get_carousel_state() ? 1 : 0);
   print_uint8_base2(limit_state);
   printPgmString(PSTR("/\r\n"));
 }

--- a/stepper.c
+++ b/stepper.c
@@ -533,8 +533,6 @@ ISR(TIMER4_COMPA_vect)
       return; // Nothing to do but exit.
     }
   }
-  // Check probing state.
-  probe_state_monitor();
 
   if(settings.mag_gap_enabled) {
    // Monitor magazine probe to look for missing magazines on carousel
@@ -585,7 +583,10 @@ ISR(TIMER4_COMPA_vect)
 
   if (limits.isservoing) 
     st_force_check();
-  
+ 
+  // Used to move to carousel magazine
+  probe_carousel_monitor();
+
   // Check if probe is reached, if probing
   if (probe.isprobing)
     probe_check();

--- a/system.c
+++ b/system.c
@@ -266,36 +266,7 @@ uint8_t system_execute_line(char *line)
           if ( line[++char_counter] != 0 ) { return(STATUS_INVALID_STATEMENT); }
           else { report_ngc_parameters(); }
           break;
-        case 'A': // Probe: Specify sensor, axis and specified directionX,
-          char_counter++;
-          uint8_t axis = line[char_counter];
-          axis = get_axis_idx(axis);
-          //Axis
-          if ((axis == N_AXIS) || (line[++char_counter] != ' '))
-            return(STATUS_INVALID_STATEMENT);
-          // Sensor
-          char_counter++;
-          if (!read_float(line, &char_counter, &value))
-            return(STATUS_BAD_NUMBER_FORMAT);      
-          uint8_t sensor = (uint8_t)value;
-          // Check if sensor is valid
-          if (sensor >= E_SENSOR_TYPES)
-            return(STATUS_BAD_NUMBER_FORMAT);
-          // Direction
-          if (line[char_counter] != ' ')
-            return(STATUS_INVALID_STATEMENT);
-          char_counter++;
-          if (!read_float(line, &char_counter, &value))
-            return(STATUS_BAD_NUMBER_FORMAT);      
-          uint8_t dir = (uint8_t)value;
-          if (dir > 1)
-            return(STATUS_BAD_NUMBER_FORMAT);
-          probe_move_to_sensor(sensor, axis, dir);
-          // End of system command:
-          if (line[++char_counter] != 0)
-            return(STATUS_INVALID_STATEMENT);
-          break;
-        case 'P': // Set force sensitivity parameter. Avoids hastle of changing eeprom settings.
+       case 'P': // Set force sensitivity parameter. Avoids hastle of changing eeprom settings.
           char_counter++;
           if (!read_float(line, &char_counter, &parameter)){
             return(STATUS_BAD_NUMBER_FORMAT);

--- a/system.h
+++ b/system.h
@@ -102,7 +102,6 @@ extern system_t sys;
 
 typedef struct {
   volatile uint8_t execute;      // Global system runtime executor bitflag variable. See EXEC bitmasks.
-  volatile uint8_t probe_state;   // Probing state value.  Used to coordinate the probing cycle with stepper ISR.
   volatile uint8_t limits;                 //limit
   volatile uint8_t report_rqsts;   //requestsd reports
 } sys_flags_t;

--- a/systick.c
+++ b/systick.c
@@ -46,7 +46,7 @@ void systick_service_callbacks()
   while (systick_callbacks_array[idx].callback_time <= sys_tick && idx < systick_len) {
     idx++;
   }
-  
+
   while (idx > 0) {
     // Call the callback function
     systick_callbacks_array[0].cb_function();


### PR DESCRIPTION
The probe command is now a gcode command and works with the existing probe code used to move to a magazine on the carousel.

mc_probe_cycle() in motion_control.c is replaced in probe.c.

Backwards compatible with motion - The old motion will work with this code as well as the new motion that measures keys with a probe.