### PR TITLE
Add settings to Grbl, remove Load Cell C Flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,6 @@ ifneq ($(SPI),)
   CFLAGS += -DSPI_STEPPER_DRIVER
 endif
 
-ifneq ($(USE_LOAD_CELL),)
-  CFLAGS += -DUSE_LOAD_CELL
-endif
-
 ifneq ($(USE_CAROUSEL_LOSS),)
   CFLAGS += -DUSE_CAROUSEL_LOSS
 endif

--- a/adc.c
+++ b/adc.c
@@ -2,6 +2,7 @@
 #include "system.h"
 #include "adc.h"
 #include "nuts_bolts.h"
+#include "settings.h"
 
 #define ADMUX_SELECTION_MASK    0x7
 #define MUX5_MASK               0x8
@@ -9,16 +10,12 @@
 channel_t active_channel = 0;
 
 uint8_t channel_map[VOLTAGE_SENSOR_COUNT] = {
-  F_ADC,
-  Y_ADC,
-  Z_ADC,
-  C_ADC,
-  #ifdef USE_LOAD_CELL
-    LC_ADC,
-  #else
-    F_ADC,
-  #endif
-  RD_ADC
+    X_ADC,
+    Y_ADC,
+    Z_ADC,
+    C_ADC,
+    0,  // This value is initialized adc_init
+    RD_ADC
 };
 
 void setup_adc_channel(uint8_t channel) 
@@ -74,12 +71,15 @@ void adc_init()
   // These pins are initialized here because there are 
   // no other where the pins can be initialized with the
   // associated peripherals, such as with the stepper motors.
-  
-  #ifdef USE_LOAD_CELL
-    LC_DDR &= ~(LC_MASK);  
-  #else
+
+
+  if (settings.use_load_cell) {
+    LC_DDR &= ~(LC_MASK);
+    channel_map[FORCE] = LC_ADC;
+  } else {
     FORCE_DDR &= ~(FORCE_MASK); // Force servo
-  #endif
+    channel_map[FORCE] = F_ADC;
+  }
 
   // Set revision divider pin as an input
   RD_DDR &= ~(RD_MASK);

--- a/defaults.h
+++ b/defaults.h
@@ -110,6 +110,8 @@
   #define DEFAULT_COUNTS_PER_IDX 4000  //counts per encoder rev
   #define DEFAULT_FORCE_SENSOR_LEVEL 77 // 1.5V out of 5.0V=255 max
   #define DEFAULT_MAG_GAP_LIMIT 12.5 //in mm (units)
+  #define DEFAULT_MAG_GAP_ENABLED false
+  #define DEFAULT_USE_LOAD_CELL false
 #endif
 
 #ifdef DEFAULTS_BENCH

--- a/report.c
+++ b/report.c
@@ -227,6 +227,8 @@ void report_grbl_settings() {
   printPgmString(PSTR(" (magazine gap limit, mm)"));
   printPgmString(PSTR("\r\n$41=")); print_uint8_base10(settings.mag_gap_enabled);
   printPgmString(PSTR(" (magazine gap enabled, bool)"));
+  printPgmString(PSTR("\r\n$42=")); print_uint8_base10(settings.use_load_cell);
+  printPgmString(PSTR(" (use load cell, bool)"));
   /* End KEYME Specific */
   printPgmString(PSTR("\r\n"));
 }

--- a/settings.c
+++ b/settings.c
@@ -103,7 +103,9 @@ void settings_reset() {
   settings.microsteps = DEFAULT_MICROSTEPPING;
   settings.decay_mode = DEFAULT_DECAY_MODE;
   settings.force_sensor_level = DEFAULT_FORCE_SENSOR_LEVEL;
+  settings.mag_gap_enabled = DEFAULT_MAG_GAP_ENABLED;
   settings.mag_gap_limit = DEFAULT_MAG_GAP_LIMIT;
+  settings.use_load_cell = DEFAULT_USE_LOAD_CELL;
   write_global_settings();
 }
 
@@ -241,6 +243,7 @@ uint8_t settings_store_global_setting(int parameter, float value) {
     case 39: settings.force_sensor_level = value; break;
     case 40: settings.mag_gap_limit = value; break;
     case 41: settings.mag_gap_enabled = value; break;
+    case 42: settings.use_load_cell = value; break;
     default:
       return(STATUS_INVALID_STATEMENT);
   }

--- a/settings.h
+++ b/settings.h
@@ -72,21 +72,21 @@ typedef struct {
   uint8_t pulse_microseconds;
   uint8_t step_invert_mask;
   uint8_t dir_invert_mask;
-  uint8_t stepper_idle_lock_time; // If max value 255, steppers do not disable.
+  uint8_t stepper_idle_lock_time;  // If max value 255, steppers do not disable.
   float junction_deviation;
   float arc_tolerance;
   uint8_t flags;  // Contains default boolean settings
   uint8_t homing_dir_mask;
-  float homing_feed_rate; //slow resolve sensor
+  float homing_feed_rate;  //slow resolve sensor
   float homing_seek_rate[N_AXIS]; //seek to sensor
   uint16_t homing_debounce_delay;
   float homing_pulloff ;
-  uint8_t microsteps; //2 bits per motor
-  uint8_t decay_mode; //0..3  slow-->fast
-  uint8_t force_sensor_level; //0..255  low-->high sensitivity
-  float mag_gap_limit; // Maximum gap between two magazines at which point an alarm is thrown
-  uint8_t mag_gap_enabled; //If 0, then do not check the gap between magazines
-//  uint8_t status_report_mask; // Mask to indicate desired report data.
+  uint8_t microsteps;  //2 bits per motor
+  uint8_t decay_mode;  //0..3  slow-->fast
+  uint8_t force_sensor_level;  //0..255  low-->high sensitivity
+  float mag_gap_limit;  // Maximum gap between two magazines at which point an alarm is thrown
+  uint8_t mag_gap_enabled;  //If 0, then do not check the gap between magazines
+  uint8_t use_load_cell;  // 0 - Force Sensor, 1 - Load Cell
 } settings_t;
 extern settings_t settings;
 


### PR DESCRIPTION
The use of the load cell is no longer configured with a compiler flag, but rather in the Grbl settings config file. 

Once Grbl 3.6 rolls out, we should add these settings (and the magazine gap checking settings) to `motion/config/grbl_eeprom_settings.json`. 

Adding this change to Grbl will not break Motion. However, if these settings are added to `motion/config/grbl_eeprom_settings.json` it will not work Grbl 3.5.