### PR TITLE
Change ADC reading interval for reporting

### DIFF
--- a/signals.c
+++ b/signals.c
@@ -12,7 +12,7 @@
 #include "systick.h"
 
 #define N_FILTER 3
-#define SIGNALS_DEFAULT_INTERVAL 1000 
+#define SIGNALS_DEFAULT_INTERVAL 100 
 #define X_BUF(i) adc_samples_x[FORCE_VALUE_INDEX][i]
 
 // Unfiltered ADC readings


### PR DESCRIPTION
Shorten the interval at which we sample ADC values for reporting. For load cell calibration, a second is a bit too long, which can cause difficulty when adjusting the load cell pot.

A 200 ms interval should be fine.