### PR TITLE
Add debug messages to be displayed in MOTION

### DIFF
--- a/report.c
+++ b/report.c
@@ -100,6 +100,15 @@ void report_status_message(uint8_t status_code)
   }
 }
 
+// Prints debug message which shows up in MOTION
+void report_debug_message(const char *s)
+{
+  printPgmString(PSTR("DEBUG: "));
+  while (*s)
+    printString(s++);
+
+}
+
 // Prints alarm messages.
 void report_alarm_message(int8_t alarm_code)
 {

--- a/report.h
+++ b/report.h
@@ -66,6 +66,9 @@
 // Prints system status messages.
 void report_status_message(uint8_t status_code);
 
+// Prints debug message which shows up in MOTION
+void report_debug_message(const char *s);
+
 // Prints system alarm messages.
 void report_alarm_message(int8_t alarm_code);
 


### PR DESCRIPTION
This change allows us to print debug messages which can be displayed in Motion. It's very useful for debugging Grbl.

See https://github.com/keyme/kiosk/pull/8756