### PR TITLE
Move carousel monitor after probe check

### DIFF
--- a/stepper.c
+++ b/stepper.c
@@ -609,13 +609,13 @@ ISR(TIMER4_COMPA_vect)
 
   if (limits.isservoing) 
     st_force_check();
- 
-  // Used to move to carousel magazine
-  probe_carousel_monitor();
 
   // Check if probe is reached, if probing
   if (probe.isprobing)
     probe_check();
+
+  // Used to move to carousel magazine
+  probe_carousel_monitor();
 
   st.step_count--; // Decrement step events count
   if (st.step_count == 0) {


### PR DESCRIPTION
This should stop random wait_rotate errors from cropping up as the
decision to stop rotating will come before we measure the carousel
probe (meaning that the probe being tripped will already have
registered, and should therefore also be true for the carousel_monitor
code)

Closes #76 