### PR TITLE
PROBING: Fix probe position report

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -176,7 +176,10 @@ void probe_move_to_sensor(float * target, float feed_rate, uint8_t invert_feed_r
  
   uint8_t probe_fail;
   probe_fail = !probe_loop();
-  
+ 
+  if (!probe_fail)
+    memcpy(sys.probe_position, sys.position, sizeof(float) * N_AXIS);
+
   if (sensor == MAG_SENSOR) {
     probe_fail = (probe.carousel_probe_state == PROBE_ACTIVE);
     if (probe_fail)


### PR DESCRIPTION
Fixes a bug that caused the wrong probe position to be reported to motion.

Note @mdicicco. This fixes the behaviour that I showed you where the x-axis homes after probing when we tell the y-axis to move to a specific point. The reason is that grbl though that it should go to a negative position.