### PR TITLE
Roll version to 0.3.8. Add version string to binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
+VERSION = 0.3.8
+
 DEVICE     ?= atmega2560
 CLOCK      = 16000000
 PORT       ?= /dev/ttyUSB0
@@ -45,7 +47,7 @@ FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m
 
 AVRDUDE = avrdude  $(PROGRAMMER) -p $(DEVICE) -B 10 -F -D
 CFLAGS = -Wall -Werror -Wextra -Os -fstack-usage --std=c11 \
-	-DF_CPU=$(CLOCK) -mmcu=$(DEVICE)
+	-DF_CPU=$(CLOCK) -mmcu=$(DEVICE) -DGRBL_VERSION=$(VERSION)
 COMPILE = avr-gcc $(CFLAGS) -I. -ffunction-sections
 
 ifneq ($(SPI),)

--- a/main.c
+++ b/main.c
@@ -45,6 +45,11 @@ system_t sys = {
   .lock_mask = STEPPERS_LONG_LOCK_MASK,
 };
 
+#ifndef GRBL_VERSION
+  #error "GRBL_VERSION is not defined, please ensure it is defined in the Makefile"
+#endif
+const char* version_string = "VERSION=" XSTR(GRBL_VERSION);
+
 volatile sys_flags_t sysflags;
 
 int main(void)

--- a/report.c
+++ b/report.c
@@ -158,7 +158,7 @@ void report_feedback_message(uint8_t message_code)
 // Welcome message
 void report_init_message()
 {
-  printPgmString(PSTR("\r\nGrbl " GRBL_VERSION " ['$' for help]\r\n"));
+  printPgmString(PSTR("\r\nGrbl " XSTR(GRBL_VERSION) " ['$' for help]\r\n"));
 }
 
 // Grbl help message
@@ -377,7 +377,7 @@ void report_startup_line(uint8_t n, char *line)
 // Prints build info line
 void report_build_info(char *line)
 {
-  printPgmString(PSTR("[" GRBL_VERSION ", " GRBL_VERSION_BUILD " (" GRBL_PLATFORM ") :"));
+  printPgmString(PSTR("[" XSTR(GRBL_VERSION) ", " GRBL_VERSION_BUILD " (" GRBL_PLATFORM ") :"));
   printString(line);
   printPgmString(PSTR("]\r\n"));
 }

--- a/settings.h
+++ b/settings.h
@@ -25,8 +25,17 @@
 #include "system.h"
 
 
-// define GRBL version and build
-#define GRBL_VERSION "0.9K.3.7"
+// This is a bit of compiler magic to ensure that we don't
+// accidentally optimize away variables that are only used by external
+// tools (version numbers, ident blocks, etc)
+#define ALWAYS_KEEP(v) __asm__ __volatile__("" :: "m" (v))
+
+// This is a preprocessor trick. STR simply token pastes the value
+// given to it. By wrapping a defined value in XSTR, it forces the
+// evaluation of the token before pasting. So if you defined 'VERSION'
+// via -DVERSION=foo, XSTR(VERSION) == "foo", and STR(VERSION) == "VERSION"
+#define STR(s) #s
+#define XSTR(s) STR(s)
 
 #define GRBL_VERSION_BUILD __DATE__ " " __TIME__
 


### PR DESCRIPTION
This completes grbl's transition to semantic versioning and adds the
version string to the binary, allowing us to do automated updates