### PR TITLE
PROBING: Add front and back sensors

### DIFF
--- a/probe.c
+++ b/probe.c
@@ -50,7 +50,14 @@ static struct {
     .port = &MAGAZINE_ALIGNMENT_PORT
   },
   {
-    .idx = KEY_SENSOR,
+    .idx = KEY_SENSOR_FRONT,
+    .mask = (1 << Z_LIMIT_BIT),
+    .ddr = &LIMIT_DDR,
+    .in_port = &LIMIT_PIN,
+    .port = &LIMIT_PORT
+  },
+  {
+    .idx = KEY_SENSOR_BACK,
     .mask = (1 << Z_LIMIT_BIT),
     .ddr = &LIMIT_DDR,
     .in_port = &LIMIT_PIN,

--- a/probe.h
+++ b/probe.h
@@ -30,7 +30,8 @@ enum e_sensor {
   MAG_SENSOR = 0,
   // For now, this is mapped to the gripper's home sensor, it should be changed
   // when we get new hardware to support key measurements with probing
-  KEY_SENSOR,
+  KEY_SENSOR_FRONT,
+  KEY_SENSOR_BACK,
   E_SENSOR_TYPES
 };
 


### PR DESCRIPTION
Add front and back key sensors for key measurements. The indices of the sensors correspond to `kiosk/motion/config/sensors.json` in https://github.com/keyme/kiosk/pull/9020.

For the moment, these sensors are mapped to the cutter home sensor, which we use for testing this code, until we figure out the hardware. This code will become necessary once the measure code in kiosk gets merged.