### PR TITLE
BUGFIX: Add always keep to version number

### DIFF
--- a/main.c
+++ b/main.c
@@ -54,6 +54,9 @@ volatile sys_flags_t sysflags;
 
 int main(void)
 {
+  // Ensure that the compiler doesn't try to throw out the version string
+  ALWAYS_KEEP(version_string);
+
   // Initialize system upon power-up.
   serial_init();   // Setup serial baud rate and interrupts
   #ifdef SPI_STEPPER_DRIVER


### PR DESCRIPTION
This will prevent GCC from ever accidentally optimizing out the version
number.  0.3.9 (as deployed) is fine, but this way we won't run into
future issues