### PR TITLE
BUGFIX: Remove probe special line reporting

### DIFF
--- a/gcode.c
+++ b/gcode.c
@@ -973,8 +973,6 @@ uint8_t gc_execute_line(char *line)
         case MOTION_MODE_PROBE:          
           probe_move_to_sensor(gc_block.values.xyz, gc_state.feed_rate,
           gc_state.modal.feed_rate, gc_block.values.n, gc_block.values.p); 
-          linenumber_insert(LINENUMBER_PROBE);
-          request_eol_report();
           retval = STATUS_QUIET_OK;
 
       }


### PR DESCRIPTION
This is a bug fix for the race condition that caused some of the calibration scripts to fail when moving to a magazine.

I tested this code by cutting keys and running different calibration scripts that rely on probing. `probe_cb` in `motion/motor.py` still gets called.

See https://github.com/keyme/grbl/pull/90 and `motion/grbl_driver.py` in the kiosk repo. You need to be fairly familiar with Grbl and `grbl_driver.py` in motion to follow the following discussion:

It turns out we report the end of probing more than once and in different ways:
1) We report it with the `report_probe_parameters` function in Grbl which sends the 'PRB' code to grbl_driver in motion. This causes the `_parseresp` function to set 'type' to 'Response.PROBE' in its return dictionary.
2) We also report the special probing linenumber, 16384, to grbl_driver. In grbl_driver. If you look in the "<(.*):(.*):(.*):(\d+)>" regex, you'll see a function `_decode_linenum(line)` that is called. Inside `_decode_linenum`, the linetype is set to Response.PROBE for the probing special linenumber. Response.PROBE is then set as the value for the 'type' field which `_parseresp` returns.

In other words, for each probe, both these events occur and Response.PROBE will be returned on two seperate occasions, which confuses motion in some way.

The reason that the special linenumber reporting was added in https://github.com/keyme/grbl/pull/90, is because I thought there might be code that depends on this linenumber being reported and used in `_decode_linenum`, which introduced this race condition. It is strange that there are two ways of reporting `Response.PROBE` from `_parseresp`. It is also strange that there is a statement in `_decode_linenum` that checks if the linenumber is equal to `GRBL_PROBE_LINENUM`, but it wasn't reported from Grbl before https://github.com/keyme/grbl/pull/90 (which brings me back to the reason why I reported it from Grbl in https://github.com/keyme/grbl/pull/90). I am not sure what the intention was by doing so. If anyone has some insight as to why it is the case, please share it, but as far as I am concerned, it is unnecessary and the redundant reporting causes the race condition.

So by removing the special linenumber reporting from Grbl, we rely on `report_probe_parameters` in Grbl to report the `PRB` 'codeword' which will cause `_parseresp` to return Response.PROBE in the type field. 

Sorry about the lengthy discussion, but I want to make sure that we know why we made these changes if we ever need to refer back to them in the future.



@Jeff-Ciesielski @joebro391