### PR TITLE
REPORTING: Remove heartbeat. Only report changes

### DIFF
--- a/progman.c
+++ b/progman.c
@@ -64,13 +64,13 @@ bool progman_handle_runtime_cmd(char data)
     /* Call motion control reset routine. */
     mc_reset();
     break;
-  case '\n':			/* Intentional fall through */
+  case '\n':    /* Intentional fall through */
   case '\r':
     /* If we got a bare newline character out of context, it's likely
        due to the fact that our previous character was consumed as
        a runtime command, so we should just swallow it */
     if ((progman.line_pos < 1) &&
-	(E_PROGMAN_CONSUMING == progman.state)) {
+        (E_PROGMAN_CONSUMING == progman.state)) {
       report_status_message(STATUS_OK);
       break;
     }
@@ -138,7 +138,7 @@ bool progman_validate_gcode_line(void)
       continue;
     default:
       if (progman.line_assy[i] < ' ' || progman.line_assy[i] > '~') {
-	return false;
+        return false;
       }
     }
   }

--- a/report.c
+++ b/report.c
@@ -490,9 +490,9 @@ uint8_t report_realtime_status()
 
 void report_limit_pins()
 {
-  uint8_t limit_state = LIMIT_PIN & LIMIT_MASK;
+  uint8_t limit_state = sys.limit_state;
   if (bit_istrue(settings.flags,BITFLAG_INVERT_LIMIT_PINS)) {
-         limit_state^=LIMIT_MASK;
+         limit_state ^= LIMIT_MASK;
   }
   printPgmString(PSTR("/"));
   printInteger((ESTOP_PIN>>ESTOP_BIT)&1);

--- a/system.h
+++ b/system.h
@@ -91,12 +91,15 @@
 typedef struct {
   uint8_t abort;                 // System abort flag. Forces exit back to main loop for reset.
   uint16_t state;                 // Tracks the current state of Grbl.
+  uint16_t old_state;            // Keep track of state changes
   uint8_t flags;                 // see SYSFLAG_xxx above
   uint8_t alarm;                 // see ALARM_xxx above. which alarm(s) are active
   int32_t position[N_AXIS];      // Real-time machine (aka home) position vector in steps.
                                  // NOTE: This may need to be a volatile variable, if problems arise.
   int32_t probe_position[N_AXIS]; // Last probe position in machine coordinates and steps.
   uint8_t lock_mask;             // Mask which determines the state of axis 'locking' (aka braking)
+  uint8_t limit_state;           // State of XYZC limit pins
+  uint8_t old_limit_state;       // Keep track of limit state changes
 } system_t;
 extern system_t sys;
 


### PR DESCRIPTION
With this update, status and limit reports are only sent when the status or the input on the limit pins change,  as opposed to every `x` milliseconds.

@Jeff-Ciesielski 