### PR TITLE
VERSION: Roll version to 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
-VERSION = 0.3.11
+VERSION = 0.3.12
 
 DEVICE     ?= atmega2560
 CLOCK      = 16000000


### PR DESCRIPTION
Version 3.12:

Removes heartbeat packets (we only get change notifications now)
Re-write of serial driver and gqueue (To eliminate checksum errors)
Removal of load cell offset (calculations now take that into account)
