### PR TITLE
MOTOR: Add motor_driver and individually modify driver fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ CLOCK      = 16000000
 PORT       ?= /dev/ttyUSB0
 PROGRAMMER ?= -c wiring -P $(PORT) -v -v
 OBJECTS    = main.o motion_control.o gcode.o spindle_control.o serial.o \
-             protocol.o stepper.o eeprom.o settings.o planner.o magazine.o nuts_bolts.o limits.o \
-             print.o probe.o report.o system.o counters.o gqueue.o progman.o adc.o spi.o signals.o systick.o
+             protocol.o stepper.o eeprom.o settings.o planner.o magazine.o \
+             nuts_bolts.o limits.o print.o probe.o report.o system.o \
+             counters.o gqueue.o progman.o adc.o spi.o signals.o systick.o \
+             motor_driver.o
 
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m

--- a/motor_driver.c
+++ b/motor_driver.c
@@ -1,0 +1,90 @@
+#include <stdio.h>
+
+#include "motor_driver.h"
+#include "nuts_bolts.h"
+#include "spi.h"
+
+#define ADDRESS_IDX 5U
+
+#define DECMOD_MASK     0x0F
+#define DECMOD_IDX      8U
+
+#define TORQUE_MASK      0xFF
+#define TORQUE_IDX       0
+
+#define ENABLE_MASK     0x1
+#define ENABLE_IDX      0
+
+#define STEPS_MASK      0x0F
+#define STEPS_IDX       3U
+
+void _motor_drv_write_reg(enum stepper_e stepper, enum address_e address, uint8_t * data)
+{
+  uint8_t data_out[2] = {(address << ADDRESS_IDX) | (data[1] & 0x0F), data[0]};
+
+  bit_true(SCS_PORT, 1 << scs_pin_lookup[stepper]);
+  spi_write(data_out, 2);
+  bit_false(SCS_PORT, 1 << scs_pin_lookup[stepper]);
+
+}
+
+void _motor_drv_read_reg(enum stepper_e stepper,
+                         enum address_e address,
+                         uint8_t * data)
+{
+  uint8_t data_out[2] = {address << ADDRESS_IDX, 0};
+  bit_true(SCS_PORT, 1 << scs_pin_lookup[stepper]);
+  spi_transact_array(data_out, data, 2);
+  bit_false(SCS_PORT, 1 << scs_pin_lookup[stepper]);
+}
+
+void _motor_drv_set_val(enum stepper_e stepper,
+                        enum address_e address,
+                        uint8_t idx,
+                        uint8_t mask,
+                        uint8_t val)
+{
+  uint8_t data_array[] = {0, 0};
+  uint16_t data = 0;
+  /* Read the register */
+  _motor_drv_read_reg(stepper, address, data_array);
+
+  data = data_array[0] | (data_array[1] << 8);
+
+  /* Clear the bits that need to be set */
+  data &= (mask << idx);
+
+  /* Set the new value */
+  data |= (val & mask) << idx;
+
+  data_array[0] = (data & 0xFF00) >> 8;
+  data_array[1] = data & 0xFF;
+
+  /* Write the updated value to the register */
+  _motor_drv_write_reg(stepper, address, data_array);
+}
+
+void motor_drv_set_decay_mode(enum stepper_e stepper, enum decmod_e decmod)
+{
+  _motor_drv_set_val(stepper, DECAY, DECMOD_IDX, DECMOD_MASK, decmod);
+}
+
+void motor_drv_set_torque(enum stepper_e stepper, uint8_t torque)
+{
+  _motor_drv_set_val(stepper, TORQUE, TORQUE_IDX, TORQUE_MASK, torque);
+}
+
+void motor_drv_set_micro_stepping(enum stepper_e stepper, enum steps_e steps)
+{
+  _motor_drv_set_val(stepper, CTRL, STEPS_IDX, STEPS_MASK, steps);
+}
+
+void motor_drv_enable_motor(enum stepper_e stepper)
+{
+  _motor_drv_set_val(stepper, CTRL, ENABLE_IDX, ENABLE_MASK, 1);
+}
+
+void motor_drv_disable_motor(enum stepper_e stepper)
+{
+  _motor_drv_set_val(stepper, CTRL, ENABLE_IDX, ENABLE_MASK, 0);
+}

--- a/motor_driver.h
+++ b/motor_driver.h
@@ -1,0 +1,58 @@
+#ifndef MOTOR_DRIVER_H
+#define MOTOR_DRIVER_H
+
+#include "system.h"
+
+enum address_e {
+  CTRL = 0,
+  TORQUE,
+  OFF,
+  BLANK,
+  DECAY,
+  STALL,
+  DRIVE,
+  STATUS
+};
+
+enum steps_e {
+  FULL = 0,
+  HALF,
+  QUARTER,
+  EIGHTH,
+  SIXTEENTH,
+  THIRTY_SECOND,
+  SIXTY_FOURTH,
+  ONE_TWENTY_EIGHTH
+};
+
+enum stepper_e {
+  XTABLE = 0,
+  YTABLE,
+  GRIPPER,
+  CAROUSEL
+};
+
+/* The order of the entries in this enum is important */
+enum decmod_e {
+  SLOW = 0,
+  SLOW_INCR_MIXED_DECR,
+  FAST,
+  MIXED,
+  SLOW_INCR_AUTO_MIXED_DECR,
+  AUTO_MIXED
+};
+
+static const uint8_t scs_pin_lookup[4] = {
+  SCS_XTABLE_PIN,
+  SCS_YTABLE_PIN,
+  SCS_GRIPPER_PIN,
+  SCS_CAROUSEL_PIN
+};
+
+void motor_drv_set_decay_mode(enum stepper_e stepper, enum decmod_e decmod);
+void motor_drv_set_torque(enum stepper_e stepper, uint8_t torque);
+void motor_drv_set_micro_stepping(enum stepper_e stepper, enum steps_e steps);
+void motor_drv_enable_motor(enum stepper_e stepper);
+void motor_drv_disable_motor(enum stepper_e stepper);
+
+#endif //MOTOR_DRIVER_H


### PR DESCRIPTION
This change allows us to update certain fields in the new motor driver's register map.

Due to a hardware bug, we cannot test this yet. However, this is not being used and we are not checking in the grbl hex file yet, so it is safe to review and check in. It compiles.

See sections 7.5 and 7.6 of the [datasheet](http://www.ti.com/lit/ds/symlink/drv8711.pdf) for reference.

@Jeff-Ciesielski 