### PR TITLE
PROTOCOL: Flush any pending line numbers when idle

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -191,6 +191,15 @@ void protocol_execute_runtime()
 
   st_check_disable();
 
+  /* TODO: Figure out what exactly is causing this off-by-one type
+   * error in the reporting system */
+  /* If we're idle and there are line numbers that have not been
+   * reported, flush out the buffer to ensure our cutting software
+   * fires all of it's associated callbacks */
+  if (sys.state == STATE_IDLE && linenumber_peek()) {
+    request_eol_report();
+  }
+
 
   if (rt_exec) { // Enter only if any bit flag is true
 


### PR DESCRIPTION
There appears to be a race condition that prevents the reporting system
from actually reporting all completed lines.  I have a sneaking
suspicion that it was introduced while trying to combat lost linenumbers
on 0-length moves / alarms, and has existed for quite some time, but was
being masked by the streaming status reports.  When we moved back to
reactive/line end reports, this condition cropped back up as we weren't
constantly pinging the line number report.