### PR TITLE
MOTOR DRV: Report driver registers and disable other SPI devices

### DIFF
--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -13,13 +13,19 @@
 #define TX_BUFFER_SIZE          128
 #define BLOCK_BUFFER_SIZE       48
 #define LINE_BUFFER_SIZE        255
+/* SPI PORTS */
+#define SPI_DDR                 DDRB 
+#define SPI_PORT                PORTB
+#define SPI_MOSI                PB2
+#define SPI_MISO                PB3
+#define SPI_SCK                 PB1
 
 //Slave Chip Selects for stepper motors
 #define SCS_XTABLE_PIN          PC6
 #define SCS_YTABLE_PIN          PC5
 #define SCS_CAROUSEL_PIN        PC7
 #define SCS_GRIPPER_PIN         PC4
-#define SCS_MASK  (1 << SCS_XTABLE_PIN) | (1 << SCS_YTABLE_PIN) | (1 << SCS_CAROUSEL_PIN) | (1 << SCS_GRIPPER_PIN)
+#define SCS_MASK  ((1 << SCS_XTABLE_PIN) | (1 << SCS_YTABLE_PIN) | (1 << SCS_CAROUSEL_PIN) | (1 << SCS_GRIPPER_PIN))
 
 // Note - All steppers need to be on the same port,
 // if not, use the commented section below
@@ -32,6 +38,20 @@
 #define SCS_GRIPPER_DDR_PIN     DDC4
 #define SCS_DDR_MASK (1 << SCS_XTABLE_DDR_PIN) | (1 << SCS_YTABLE_DDR_PIN) | (1 << SCS_CAROUSEL_DDR_PIN) | (1 << SCS_GRIPPER_DDR_PIN)
 
+/* Chip selects for digital pots */
+#define SCS_DIG_POT_PORT            PORTC
+#define SCS_DIG_POT_DDR             DDRC
+#define SCS_DIG_POT_GAIN            PC0
+#define SCS_DIG_POT_CAL             PC1
+#define SCS_DIG_POT_GAIN_DDR_PIN    DDC0
+#define SCS_DIG_POT_CAL_DDR_PIN     DDC1
+
+/* Chip select for SRAM */
+#define SCS_SRAM_PORT           PORTC
+#define SCS_SRAM_PIN            PC3
+#define SCS_SRAM_DDR            DDRC
+#define SCS_SRAM_DDR_PIN        DDC3
+
 // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
 #define STEP_DDR      DDRH
 #define STEP_PORT     PORTH
@@ -41,6 +61,14 @@
 #define Z_STEP_BIT        2 // Atmega2560 pin 14 / Arduino Digital Pin xx
 #define C_STEP_BIT        3 // Atmega2560 pin 15 / Arduino Digital Pin 6
 #define STEP_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)|(1<<C_STEP_BIT)) // All step bits
+
+/* Motor driver resets */
+#define MOTOR_RESET_LINE_DRIVER_PIN             PG2
+#define MOTOR_RESET_LINE_DRIVER_DDR_PIN         DDG2
+#define MOTOR_RESET_PIN                         PG0
+#define MOTOR_RESET_PORT                        PORTG
+#define MOTOR_RESET_DDR                         DDRG
+#define MOTOR_RESET_DDR_PIN                     DDG0
 
 // Define step direction output pins. NOTE: All direction pins must be on the same port.
 #define DIRECTION_DDR      DDRH

--- a/main.c
+++ b/main.c
@@ -31,6 +31,7 @@
 #include "limits.h"
 #include "probe.h"
 #include "magazine.h"
+#include "motor_driver.h"
 #include "report.h"
 #include "counters.h"
 #include "adc.h"
@@ -57,15 +58,22 @@ int main(void)
 
   // Initialize system upon power-up.
   serial_init();   // Setup serial baud rate and interrupts
-  #ifdef SPI_STEPPER_DRIVER
-    spi_init();      // Setup SPI Control register and pins
-  #endif
 
   settings_init(); // Load grbl settings from EEPROM
+
+  /* The ESTOP input is initialized in stepper_init. When we set up digital
+  outputs that are connected to the ESTOP, they might get toggled. For safety,
+  initialize any outputs connected to the ESTOP after stepper_init. For example:
+  the spi driver. */
   stepper_init();  // Configure stepper pins and interrupt timers
   system_init();   // Configure pinout pins and pin-change interrupt
   counters_init(); // Configure encoder and counter interrupt.
   adc_init();
+
+  #ifdef SPI_STEPPER_DRIVER
+  spi_init();      // Setup SPI Control register and pins
+  #endif
+  motor_drv_init();
 
   SYS_EXEC = 0;   //and mapped port if different
 

--- a/motor_driver.c
+++ b/motor_driver.c
@@ -2,9 +2,11 @@
 
 #include "motor_driver.h"
 #include "nuts_bolts.h"
+#include "report.h"
 #include "spi.h"
 
-#define ADDRESS_IDX 5U
+#define ADDRESS_IDX     4U
+#define ADDRESS_MASK    0x70
 
 #define DECMOD_MASK     0x7
 #define DECMOD_IDX      8U
@@ -21,6 +23,11 @@
 #define STEPS_MASK      0x0F
 #define STEPS_IDX       3U
 
+#define REG_READ        0x80
+
+const char * reg_names[] = {"CTRL", "TORQUE", "OFF", "BLANK",
+                            "DECAY", "STALL", "DRIVE", "STATUS"};
+
 void _motor_drv_write_reg(enum stepper_e stepper, enum address_e address, uint8_t * data)
 {
   uint8_t data_out[2] = {(address << ADDRESS_IDX) | (data[1] & 0x0F), data[0]};
@@ -35,10 +42,13 @@ void _motor_drv_read_reg(enum stepper_e stepper,
                          enum address_e address,
                          uint8_t * data)
 {
-  uint8_t data_out[2] = {address << ADDRESS_IDX, 0};
+  uint8_t data_out[2] = {REG_READ | (address << ADDRESS_IDX), 0};
+
   bit_true(SCS_PORT, 1 << scs_pin_lookup[stepper]);
   spi_transact_array(data_out, data, 2);
   bit_false(SCS_PORT, 1 << scs_pin_lookup[stepper]);
+
+  data[0] &= ~(REG_READ | ADDRESS_MASK);
 }
 
 void _motor_drv_set_val(enum stepper_e stepper,
@@ -63,8 +73,28 @@ void _motor_drv_set_val(enum stepper_e stepper,
   data_array[0] = (data & 0xFF00) >> 8;
   data_array[1] = data & 0xFF;
 
+  /* Clear the bits in the address bits space */
+  data_array[1] |= ~ADDRESS_MASK;
+
   /* Write the updated value to the register */
   _motor_drv_write_reg(stepper, address, data_array);
+
+}
+
+void motor_drv_report_register_vals(enum stepper_e stepper)
+{
+  #ifdef DEBUG
+  for (int idx = 0; idx <= STATUS; idx++) {
+    char dbg_msg[30];
+    uint8_t data[2];
+    _motor_drv_read_reg(stepper, (enum address_e)idx, data);
+    snprintf(dbg_msg, 30, "%d %s MSB: %d, LSB: %d", idx, reg_names[idx],
+            data[0], data[1]);
+    report_debug_message(dbg_msg);
+  }
+  #else
+    (void)stepper;
+  #endif
 }
 
 void motor_drv_set_decay_mode(enum stepper_e stepper, enum decmod_e decmod)
@@ -95,4 +125,21 @@ void motor_drv_enable_motor(enum stepper_e stepper)
 void motor_drv_disable_motor(enum stepper_e stepper)
 {
   _motor_drv_set_val(stepper, CTRL, ENABLE_IDX, ENABLE_MASK, 0);
+}
+
+void motor_drv_init()
+{
+  /* Configure reset pin as output */
+  MOTOR_RESET_DDR |= ((1 << MOTOR_RESET_PIN) | (1 << MOTOR_RESET_LINE_DRIVER_PIN));
+
+  /* Set line driver /OE to low */
+  MOTOR_RESET_PORT &= ~(1 << MOTOR_RESET_LINE_DRIVER_PIN);
+
+  /* Toggle the motor reset pin */
+  MOTOR_RESET_PORT &= ~(1 << MOTOR_RESET_PIN);
+  delay_ms(1);
+  MOTOR_RESET_PORT |= (1 << MOTOR_RESET_PIN);
+  delay_ms(1);
+  MOTOR_RESET_PORT &= ~(1 << MOTOR_RESET_PIN);
+  delay_ms(1);
 }

--- a/motor_driver.h
+++ b/motor_driver.h
@@ -56,6 +56,10 @@ static const uint8_t scs_pin_lookup[4] = {
   SCS_CAROUSEL_PIN
 };
 
+void motor_drv_report_register_vals(enum stepper_e stepper);
+
+void motor_drv_init();
+
 void motor_drv_set_decay_mode(enum stepper_e stepper, enum decmod_e decmod);
 void motor_drv_set_torque(enum stepper_e stepper, uint8_t torque);
 void motor_drv_set_isgain(enum stepper_e stepper, enum isgain_e isgain);

--- a/spi.c
+++ b/spi.c
@@ -1,26 +1,45 @@
-/* 
+/*
   Not part of GRBL, KeyMe specific
 */
 
 #include "spi.h"
 
-#define SPI_TRANSFER_FLAG (SPSR & (1<<SPIF))
-
-
-//Setup spi
 void spi_init()
 {
 
-  DDRB = ((1 << DDB2) | (1 << DDB1) | (1 << DDB0)); //spi pins on port b MOSI SCK,SS outputs
+  /* TODO: Move these chip select initializations to
+  their respective drivers. Since we don't have drivers yet,
+  disable the CS lines here. */
+  SCS_DIG_POT_DDR |= (1 << SCS_DIG_POT_GAIN_DDR_PIN) | (1 <<  SCS_DIG_POT_CAL_DDR_PIN);
+  SCS_DIG_POT_PORT |= (1 << SCS_DIG_POT_GAIN) | (1 << SCS_DIG_POT_CAL);
 
-  SPCR = ((1 << SPE) | (1 << MSTR) | (1 << SPR0) | (1 << CPOL) | (1 << CPHA));  // SPI enable, Master, f/16
+  SCS_SRAM_DDR |= (1 << SCS_SRAM_DDR_PIN);
+  SCS_SRAM_PORT |= (1 << SCS_SRAM_PIN);
+
+  /* Configure MISO as input */
+  SPI_DDR &= ~(1 << SPI_MISO);
+
+  /* Pull-up on MISO */
+  SPI_PORT |= (1 << SPI_MISO);
+
+  /* MSB first */
+  SPCR &= ~(1 << DORD);
+
+  /* Configure MOSI, SCK as outputs */
+  SPI_DDR |= (1 << SPI_MOSI) | (1 << SPI_SCK);
 
   //Configure SCS Pins as outputs
-  bit_true(SCS_DDR_PORT, SCS_DDR_MASK); 
+  SCS_DDR_PORT |= SCS_DDR_MASK;
 
   //Set SCS to low for all steppers
-  bit_false(SCS_PORT, SCS_MASK);
+  SCS_PORT &= ~(SCS_MASK);
 
+  SPCR = ((1 << SPE)  | /* Enable */
+          (0 << SPIE) | /* Disable SPI interrupt */
+          (0 << DORD) | /* MSB first */
+          (1 << MSTR) | /* Master mode */
+          (1 << SPR1) | (0 << SPR0) | /* Set clock speed */
+          (0 << CPOL) | (0 << CPHA)); /* Mode 0 */
 }
 
 void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len)
@@ -29,25 +48,24 @@ void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len)
   uint8_t idx;
 
   for(idx = 0; idx < len; idx++) {
-
     if (dataout != NULL) {
       SPDR = dataout[idx];  //SPDR - SPI Data register
     } else {
-      SPDR = 0;    
+      SPDR = 0;
     }
 
     uint16_t timeout = 0xFFFF;
-    while(!(SPI_TRANSFER_FLAG)) {
+    while ((SPSR & (1 << SPIF)) == 0) {
       if (timeout-- == 0) {
-        return;     
-      }
-    } //Wait for transmit to be completed
+        return;
+      } /* Wait for transmit to complete */
+    }
 
     if (datain != NULL) {
       datain[idx] = SPDR;
-    } 
-  
+    }
   }
+
 }
 
 void spi_read(uint8_t * datain, uint8_t len) 


### PR DESCRIPTION
This change fixes the SPI driver. There were two problems with the SPI bus:
 * The motor drivers require an external pull-up on the SDATO/MOSI line. This is a hardware issue not reflected in the code.
 * Even though the SRAM has an external pull-up on the active-low chip select line, it was still being pulled low by the AVR. This was easily fixed by initializing the SRAM's CS pin and pulling it high with the MCU.

With this change, we are able to read the registers from the motor drivers, confirming that the SPI driver and motor driver logic is functioning correctly.

In this change, `stepper.c` is also cleaned up. Another layer, called `motor_driver` is added between the SPI driver and `stepper`.