### PR TITLE
DEVICES: AD5121 driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ OBJECTS    = main.o motion_control.o gcode.o spindle_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o \
              nuts_bolts.o limits.o print.o probe.o report.o system.o \
              counters.o gqueue.o adc.o spi.o signals.o systick.o \
-             motor_driver.o
+             motor_driver.o ad5121.o
 
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m

--- a/ad5121.c
+++ b/ad5121.c
@@ -56,7 +56,7 @@ void ad5121_write_pot(enum AD5121_ID dev_id, uint8_t val)
   struct ad5121_dev dev = devs[dev_id];
   uint8_t cmd[] = {AD_CMD_WRITE_RDAC, val};
 
-  spi_reconfigure(0, 1);
+  spi_set_mode(0, 1);
 
   /* Assert CS pin */
   *dev.cs_port &= ~(1 << dev.cs_pin);
@@ -74,7 +74,7 @@ uint8_t ad5121_read_pot(enum AD5121_ID dev_id)
   uint8_t cmd[] = {AD_CMD_READ, AD_MASK_READ_RDAC};
   uint8_t result[2] = {0};
 
-  spi_reconfigure(0, 1);
+  spi_set_mode(0, 1);
 
   /* Assert CS pin */
   *dev.cs_port &= ~(1 << dev.cs_pin);
@@ -100,7 +100,7 @@ void ad5121_store_pot(enum AD5121_ID dev_id)
   struct ad5121_dev dev = devs[dev_id];
   uint8_t cmd[] = {AD_CMD_RDAC_TO_EEPROM, 0x01};
 
-  spi_reconfigure(0, 1);
+  spi_set_mode(0, 1);
 
   /* Assert CS pin */
   *dev.cs_port &= ~(1 << dev.cs_pin);

--- a/ad5121.c
+++ b/ad5121.c
@@ -59,12 +59,12 @@ void ad5121_write_pot(enum AD5121_ID dev_id, uint8_t val)
   spi_set_mode(0, 1);
 
   /* Assert CS pin */
-  *dev.cs_port &= ~(1 << dev.cs_pin);
+  *(dev.cs_port) &= ~(1 << dev.cs_pin);
 
   spi_write(cmd, ARRAY_SIZE(cmd));
 
   /* Deassert CS pin */
-  *dev.cs_port |= 1 << dev.cs_pin;
+  *(dev.cs_port) |= 1 << dev.cs_pin;
 
 }
 
@@ -77,20 +77,20 @@ uint8_t ad5121_read_pot(enum AD5121_ID dev_id)
   spi_set_mode(0, 1);
 
   /* Assert CS pin */
-  *dev.cs_port &= ~(1 << dev.cs_pin);
+  *(dev.cs_port) &= ~(1 << dev.cs_pin);
 
   spi_write(cmd, ARRAY_SIZE(cmd));
 
   /* Deassert CS pin */
-  *dev.cs_port |= 1 << dev.cs_pin;
+  *(dev.cs_port) |= 1 << dev.cs_pin;
 
   /* Assert CS pin */
-  *dev.cs_port &= ~(1 << dev.cs_pin);
+  *(dev.cs_port) &= ~(1 << dev.cs_pin);
 
   spi_transact_array(result, result, 2);
 
   /* Deassert CS pin */
-  *dev.cs_port |= 1 << dev.cs_pin;
+  *(dev.cs_port) |= 1 << dev.cs_pin;
 
   return result[1];
 }
@@ -103,10 +103,10 @@ void ad5121_store_pot(enum AD5121_ID dev_id)
   spi_set_mode(0, 1);
 
   /* Assert CS pin */
-  *dev.cs_port &= ~(1 << dev.cs_pin);
+  *(dev.cs_port) &= ~(1 << dev.cs_pin);
 
   spi_write(cmd, ARRAY_SIZE(cmd));
 
   /* Deassert CS pin */
-  *dev.cs_port |= 1 << dev.cs_pin;
+  *(dev.cs_port) |= 1 << dev.cs_pin;
 }

--- a/ad5121.c
+++ b/ad5121.c
@@ -1,0 +1,98 @@
+#include <stdint.h>
+
+#include <avr/io.h>
+
+#include "nuts_bolts.h"
+#include "ad5121.h"
+#include "spi.h"
+
+#define AD_CMD_WRITE_RDAC     0x10
+#define AD_CMD_RDAC_TO_EEPROM 0x70
+
+#define AD_CMD_READ         0x30
+#define AD_MASK_READ_RDAC   0x00
+#define AD_MASK_READ_EEPROM 0x01
+
+struct ad5121_dev {
+  volatile uint8_t *cs_ddr;
+  uint8_t cs_ddr_mask;
+  volatile uint8_t *cs_port;
+  uint8_t cs_pin;
+};
+
+static struct ad5121_dev devs[] = {
+  {
+    /* Gain Pot */
+    .cs_ddr = &DDRC,
+    .cs_ddr_mask = DDC0,
+    .cs_port = &PORTC,
+    .cs_pin = PC0,
+  },
+  {
+    /* Offset Pot */
+    .cs_ddr = &DDRC,
+    .cs_ddr_mask = DDC1,
+    .cs_port = &PORTC,
+    .cs_pin = PC1,
+  }
+};
+
+void ad5121_init(enum AD5121_ID dev_id)
+{
+  struct ad5121_dev dev = devs[dev_id];
+
+  /* Set DDR of CS pin to output */
+  *dev.cs_ddr |= 1 << dev.cs_ddr_mask;
+
+  /* Deassert CS pin */
+  *dev.cs_port |= 1 << dev.cs_pin;
+
+}
+
+void ad5121_write_pot(enum AD5121_ID dev_id, uint8_t val)
+{
+  struct ad5121_dev dev = devs[dev_id];
+  uint8_t cmd[] = {AD_CMD_WRITE_RDAC, val};
+
+  /* Assert CS pin */
+  *dev.cs_port &= ~(1 << dev.cs_pin);
+
+  spi_write(cmd, ARRAY_SIZE(cmd));
+
+  /* Deassert CS pin */
+  *dev.cs_port |= 1 << dev.cs_pin;
+
+}
+
+uint8_t ad5121_read_pot(enum AD5121_ID dev_id)
+{
+  struct ad5121_dev dev = devs[dev_id];
+  uint8_t cmd[] = {AD_CMD_WRITE_RDAC, AD_MASK_READ_RDAC};
+  uint8_t result = 0;
+
+  /* Assert CS pin */
+  *dev.cs_port &= ~(1 << dev.cs_pin);
+
+  spi_write(cmd, ARRAY_SIZE(cmd));
+
+  spi_transact_array(&result, &result, 1);
+
+  /* Deassert CS pin */
+  *dev.cs_port |= 1 << dev.cs_pin;
+
+  return result;
+}
+
+void ad5121_store_pot(enum AD5121_ID dev_id)
+{
+  struct ad5121_dev dev = devs[dev_id];
+  uint8_t cmd[] = {AD_CMD_RDAC_TO_EEPROM, 0x01};
+
+  /* Assert CS pin */
+  *dev.cs_port &= ~(1 << dev.cs_pin);
+
+  spi_write(cmd, ARRAY_SIZE(cmd));
+
+  /* Deassert CS pin */
+  *dev.cs_port |= 1 << dev.cs_pin;
+}

--- a/ad5121.h
+++ b/ad5121.h
@@ -1,0 +1,16 @@
+#ifndef _AD5121_H_
+#define _AD5121_H_
+
+#include <stdint.h>
+
+enum AD5121_ID {
+  AD5121_0 = 0,
+  AD5121_1 = 1
+};
+
+void ad5121_init(enum AD5121_ID dev_id);
+void ad5121_write_pot(enum AD5121_ID dev_id, uint8_t val);
+uint8_t ad5121_read_pot(enum AD5121_ID dev_id);
+void ad5121_store_pot(enum AD5121_ID dev_id);
+
+#endif

--- a/ad5121.h
+++ b/ad5121.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 enum AD5121_ID {
-  AD5121_0 = 0,
-  AD5121_1 = 1
+  AD5121_GAIN = 0,
+  AD5121_CAL = 1
 };
 
 void ad5121_init(enum AD5121_ID dev_id);

--- a/main.c
+++ b/main.c
@@ -38,6 +38,7 @@
 #include "spi.h"
 #include "systick.h"
 #include "signals.h"
+#include "ad5121.h"
 
 // Declare system global variable structure
 system_t sys = {
@@ -110,6 +111,12 @@ int main(void)
     st_reset(); // Clear stepper subsystem variables.
     signals_init();
     systick_init();  // Init systick and systick callbacks
+
+    /* Initialize digital potentiometers */
+#ifdef SPI_STEPPER_DRIVER
+    ad5121_init(AD5121_0);
+    ad5121_init(AD5121_1);
+#endif
 
     // Register first signals update callback
     systick_register_callback(500, signals_callback); // Start polling ADCs 0.5 seconds after init

--- a/main.c
+++ b/main.c
@@ -114,8 +114,8 @@ int main(void)
 
     /* Initialize digital potentiometers */
 #ifdef SPI_STEPPER_DRIVER
-    ad5121_init(AD5121_0);
-    ad5121_init(AD5121_1);
+    ad5121_init(AD5121_GAIN);
+    ad5121_init(AD5121_CAL);
 #endif
 
     // Register first signals update callback

--- a/nuts_bolts.h
+++ b/nuts_bolts.h
@@ -35,6 +35,7 @@ enum e_axis {
 
 #define MM_PER_INCH (25.40)
 #define INCH_PER_MM (0.0393701)
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 
 #define TICKS_PER_MICROSECOND (F_CPU/1000000)
 

--- a/spi.c
+++ b/spi.c
@@ -4,15 +4,23 @@
 
 #include "spi.h"
 
+
+void spi_reconfigure(uint8_t cpol, uint8_t cpha)
+{
+  SPCR = ((1 << SPE)  | /* Enable */
+          (0 << SPIE) | /* Disable SPI interrupt */
+          (0 << DORD) | /* MSB first */
+          (1 << MSTR) | /* Master mode */
+          (1 << SPR1) | (0 << SPR0) | /* Set clock speed */
+          (cpol << CPOL) | (cpha << CPHA)); /* Mode 0 */
+}
+
 void spi_init()
 {
 
   /* TODO: Move these chip select initializations to
   their respective drivers. Since we don't have drivers yet,
   disable the CS lines here. */
-  SCS_DIG_POT_DDR |= (1 << SCS_DIG_POT_GAIN_DDR_PIN) | (1 <<  SCS_DIG_POT_CAL_DDR_PIN);
-  SCS_DIG_POT_PORT |= (1 << SCS_DIG_POT_GAIN) | (1 << SCS_DIG_POT_CAL);
-
   SCS_SRAM_DDR |= (1 << SCS_SRAM_DDR_PIN);
   SCS_SRAM_PORT |= (1 << SCS_SRAM_PIN);
 
@@ -34,12 +42,8 @@ void spi_init()
   //Set SCS to low for all steppers
   SCS_PORT &= ~(SCS_MASK);
 
-  SPCR = ((1 << SPE)  | /* Enable */
-          (0 << SPIE) | /* Disable SPI interrupt */
-          (0 << DORD) | /* MSB first */
-          (1 << MSTR) | /* Master mode */
-          (1 << SPR1) | (0 << SPR0) | /* Set clock speed */
-          (0 << CPOL) | (0 << CPHA)); /* Mode 0 */
+  spi_reconfigure(0, 0);
+
 }
 
 void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len)

--- a/spi.c
+++ b/spi.c
@@ -5,7 +5,7 @@
 #include "spi.h"
 
 
-void spi_reconfigure(uint8_t cpol, uint8_t cpha)
+void spi_set_mode(uint8_t cpol, uint8_t cpha)
 {
   SPCR = ((1 << SPE)  | /* Enable */
           (0 << SPIE) | /* Disable SPI interrupt */
@@ -42,7 +42,7 @@ void spi_init()
   //Set SCS to low for all steppers
   SCS_PORT &= ~(SCS_MASK);
 
-  spi_reconfigure(0, 0);
+  spi_set_mode(0, 0);
 
 }
 

--- a/spi.h
+++ b/spi.h
@@ -26,7 +26,7 @@
 #define C_SPR0 1
 
 void spi_init();
-void spi_reconfigure(uint8_t cpol, uint8_t cpha);
+void spi_set_mode(uint8_t cpol, uint8_t cpha);
 
 // Transmit an array of bytes and receive a byte for each byte transmitted
 void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len);

--- a/spi.h
+++ b/spi.h
@@ -26,6 +26,7 @@
 #define C_SPR0 1
 
 void spi_init();
+void spi_reconfigure(uint8_t cpol, uint8_t cpha);
 
 // Transmit an array of bytes and receive a byte for each byte transmitted
 void spi_transact_array(uint8_t * dataout, uint8_t * datain, uint8_t len);

--- a/system.c
+++ b/system.c
@@ -356,11 +356,11 @@ uint8_t system_execute_line(char *line)
           }
 
           switch ((int)dev_id) {
-          case AD5121_GAIN:
-          case AD5121_CAL:
-            break;
-          default:
-            return STATUS_INVALID_STATEMENT;
+            case AD5121_GAIN:
+            case AD5121_CAL:
+              break;
+            default:
+              return STATUS_INVALID_STATEMENT;
           }
 
           char command = line[char_counter++];
@@ -370,24 +370,24 @@ uint8_t system_execute_line(char *line)
              S: Store to eeprom
           */
           switch (command) {
-          case 'W':
-            if (!read_float(line, &char_counter, &value)){
-              return(STATUS_BAD_NUMBER_FORMAT);
+            case 'W':
+              if (!read_float(line, &char_counter, &value)){
+                return(STATUS_BAD_NUMBER_FORMAT);
+              }
+              ad5121_write_pot((enum AD5121_ID)dev_id, (uint8_t)value);
+              break;
+            case 'R':
+            {
+              const uint8_t result = ad5121_read_pot((enum AD5121_ID)dev_id);
+              print_uint8_base10(result);
+              printPgmString(PSTR("\r\n"));
+              break;
             }
-            ad5121_write_pot((enum AD5121_ID)dev_id, (uint8_t)value);
-            break;
-          case 'R':
-          {
-            const uint8_t result = ad5121_read_pot((enum AD5121_ID)dev_id);
-            print_uint8_base10(result);
-            printPgmString(PSTR("\r\n"));
-            break;
-          }
-          case 'S':
-            ad5121_store_pot((enum AD5121_ID)dev_id);
-            break;
-          default:
-            return STATUS_INVALID_STATEMENT;
+            case 'S':
+              ad5121_store_pot((enum AD5121_ID)dev_id);
+              break;
+            default:
+              return STATUS_INVALID_STATEMENT;
           }
           break;
         }

--- a/system.c
+++ b/system.c
@@ -356,8 +356,8 @@ uint8_t system_execute_line(char *line)
           }
 
           switch ((int)dev_id) {
-          case AD5121_0:
-          case AD5121_1:
+          case AD5121_GAIN:
+          case AD5121_CAL:
             break;
           default:
             return STATUS_INVALID_STATEMENT;

--- a/system.c
+++ b/system.c
@@ -32,6 +32,7 @@
 #include "signals.h"
 #include "probe.h"
 #include "ad5121.h"
+#include "print.h"
 
 uint32_t masterclock=0;
 //uint16_t voltage_result[VOLTAGE_SENSOR_COUNT];
@@ -363,9 +364,9 @@ uint8_t system_execute_line(char *line)
           }
 
           char command = line[char_counter++];
-
           /* Determine which command we want to execute:
              W: Write
+             R: Read
              S: Store to eeprom
           */
           switch (command) {
@@ -375,6 +376,13 @@ uint8_t system_execute_line(char *line)
             }
             ad5121_write_pot((enum AD5121_ID)dev_id, (uint8_t)value);
             break;
+          case 'R':
+          {
+            const uint8_t result = ad5121_read_pot((enum AD5121_ID)dev_id);
+            print_uint8_base10(result);
+            printPgmString(PSTR("\r\n"));
+            break;
+          }
           case 'S':
             ad5121_store_pot((enum AD5121_ID)dev_id);
             break;


### PR DESCRIPTION
Adds a really basic digital pot driver that can be controlled through a system command.

Traces look right on the board, but unfortunately I don't have the cabling to test hardware at the moment.  Will attempt to do so shortly.

@keyme/robotics 