### PR TITLE
DEVICES: Add sram driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ OBJECTS    = main.o motion_control.o gcode.o spindle_control.o serial.o \
              protocol.o stepper.o eeprom.o settings.o planner.o magazine.o \
              nuts_bolts.o limits.o print.o probe.o report.o system.o \
              counters.o gqueue.o adc.o spi.o signals.o systick.o \
-             motor_driver.o ad5121.o
+             motor_driver.o ad5121.o sram.o
 
 # FUSES      = -U hfuse:w:0xd9:m -U lfuse:w:0x24:m
 FUSES      = -U hfuse:w:0xd8:m -U lfuse:w:0xff:m

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -49,9 +49,9 @@
 
 /* Chip select for SRAM */
 #define SCS_SRAM_PORT           PORTC
-#define SCS_SRAM_PIN            PC3
+#define SCS_SRAM_PIN            PC2
 #define SCS_SRAM_DDR            DDRC
-#define SCS_SRAM_DDR_PIN        DDC3
+#define SCS_SRAM_DDR_PIN        DDC2
 
 /* Motor driver resets */
 #define MOTOR_RESET_LINE_DRIVER_PIN             PG2

--- a/main.c
+++ b/main.c
@@ -40,7 +40,7 @@
 #include "signals.h"
 #include "ad5121.h"
 #include "motor_driver.h"
-
+#include "sram.h"
 
 // Declare system global variable structure
 system_t sys = {
@@ -77,6 +77,7 @@ int main(void)
   spi_init();      // Setup SPI Control register and pins
   #endif
   motor_drv_init();
+  sram_init();
 
   SYS_EXEC = 0;   //and mapped port if different
 

--- a/sram.c
+++ b/sram.c
@@ -1,0 +1,96 @@
+#include "sram.h"
+#include "spi.h"
+#include "nuts_bolts.h"
+
+/* Least and most significant bytes of x, of type uint16_t */
+#define LSB(x) (x & 0x00FF)
+#define MSB(x) ((x & 0xFF00) >> 8)
+
+#define MODE_MASK 0xC0
+#define MODE_IDX  6U
+
+/* SPI insructions */
+enum instruction_e {
+  READ = 0x3,
+  WRITE = 0x2,
+  EDIO = 0x3B,
+  EQIO = 0x38,
+  RSTIO = 0xFF,
+  RDMR = 0x5,
+  WRMR = 0x1
+};
+
+void sram_init()
+{
+  /* Configure SCS pin as output */
+  SCS_SRAM_DDR |= (1 << SCS_SRAM_DDR_PIN);
+
+  /* Set SCS pin to high. The CS for this chip is active low */
+  SCS_SRAM_PORT &= ~(1 << SCS_SRAM_PIN);
+
+  /* SCK resting state is 0. Clock data on rising edge */
+  spi_set_mode(0, 0);
+
+  sram_set_mode(BYTE_MODE);
+}
+
+uint8_t sram_read_mode()
+{
+  spi_set_mode(0, 0);
+
+  uint8_t data_out[2] = {RDMR, 0xFF};
+  uint8_t data_in[2];
+
+  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+  spi_transact_array(data_out, data_in, 2);
+  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+
+  return (data_in[1] & MODE_MASK) >> MODE_IDX;
+}
+
+void sram_set_mode(enum sram_mode_e mode)
+{
+  spi_set_mode(0, 0);
+
+  uint8_t data_out[2] = {WRMR, mode << MODE_IDX};
+  uint8_t data_in[2];
+
+  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+  spi_transact_array(data_out, data_in, 2);
+  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+}
+
+uint8_t sram_read_byte(uint16_t addr)
+{
+  spi_set_mode(0, 0);
+
+  uint8_t data_out[4] = {READ,
+                         MSB(addr),
+                         LSB(addr),
+                         0xFF};
+  uint8_t data_in[4];
+
+  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+  spi_transact_array(data_out, data_in, 4);
+  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+
+  return data_in[3];
+
+}
+
+void sram_write_byte(uint16_t addr, uint8_t val)
+{
+  spi_set_mode(0, 0);
+
+  uint8_t data_out[4] = {WRITE,
+                         MSB(addr),
+                         LSB(addr),
+                         val};
+
+  uint8_t data_in[4];
+
+  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+  spi_transact_array(data_out, data_in, 4);
+  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+
+}

--- a/sram.c
+++ b/sram.c
@@ -60,37 +60,34 @@ void sram_set_mode(enum sram_mode_e mode)
   bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
 }
 
-uint8_t sram_read_byte(uint16_t addr)
+uint8_t _sram_transact_helper(uint8_t * data_out)
 {
+  /* Transacts the array data_out over SPI to the SRAM IC
+     and returns the last byte received. */
   spi_set_mode(0, 0);
 
-  uint8_t data_out[4] = {READ,
-                         MSB(addr),
-                         LSB(addr),
-                         0xFF};
-  uint8_t data_in[4];
+  uint8_t len = ARRAY_SIZE(data_out);
+  uint8_t data_in[len];
 
   bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-  spi_transact_array(data_out, data_in, 4);
+  spi_transact_array(data_out, data_in, len);
   bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
 
-  return data_in[3];
+  return data_in[len - 1];
 
+}
+
+uint8_t sram_read_byte(uint16_t addr)
+{
+  uint8_t data_out[4] = {READ, MSB(addr), LSB(addr), 0xFF};
+
+  return _sram_transact_helper(data_out);
 }
 
 void sram_write_byte(uint16_t addr, uint8_t val)
 {
-  spi_set_mode(0, 0);
+  /* Ignore the return value from _sram_transact_helper */
+  uint8_t data_out[4] = {WRITE, MSB(addr), LSB(addr), val};
 
-  uint8_t data_out[4] = {WRITE,
-                         MSB(addr),
-                         LSB(addr),
-                         val};
-
-  uint8_t data_in[4];
-
-  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-  spi_transact_array(data_out, data_in, 4);
-  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-
+  _sram_transact_helper(data_out);
 }

--- a/sram.h
+++ b/sram.h
@@ -1,0 +1,23 @@
+#ifndef SRAM_H
+#define SRAM_H
+
+#include "system.h"
+
+enum sram_mode_e {
+  BYTE_MODE = 0,
+  SEQ_MODE = 1U,
+  PAGE_MODE = 2U
+
+};
+
+void sram_init();
+
+uint8_t sram_read_byte(uint16_t addr);
+
+void sram_write_byte(uint16_t addr, uint8_t val);
+
+uint8_t sram_read_mode();
+
+void sram_set_mode(enum sram_mode_e mode);
+
+#endif


### PR DESCRIPTION
This is the initial version of the SRAM driver. This version of the driver supports setting the mode and writing and reading bytes to addresses.

Sequential and page read/writes can be added in the future, should we need it.

Tested by writing to and reading from SRAM (also, the motors still spin).

@Jeff-Ciesielski 