### PR TITLE
DEVICES: Refactor SRAM stuff

### DIFF
--- a/sram.c
+++ b/sram.c
@@ -34,30 +34,29 @@ void sram_init()
   sram_set_mode(BYTE_MODE);
 }
 
-uint8_t sram_read_mode()
+uint8_t _sram_mode_helper(uint8_t * data_out, uint8_t len)
 {
   spi_set_mode(0, 0);
 
-  uint8_t data_out[2] = {RDMR, 0xFF};
-  uint8_t data_in[2];
+  uint8_t data_in[len];
 
   bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-  spi_transact_array(data_out, data_in, 2);
+  spi_transact_array(data_out, data_in, len);
   bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
 
-  return (data_in[1] & MODE_MASK) >> MODE_IDX;
+  return (data_in[len - 1] & MODE_MASK) >> MODE_IDX;
+}
+
+uint8_t sram_read_mode()
+{
+  uint8_t data_out[2] = {RDMR, 0xFF};
+  return _sram_mode_helper(data_out, 2);
 }
 
 void sram_set_mode(enum sram_mode_e mode)
 {
-  spi_set_mode(0, 0);
-
   uint8_t data_out[2] = {WRMR, mode << MODE_IDX};
-  uint8_t data_in[2];
-
-  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-  spi_transact_array(data_out, data_in, 2);
-  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
+  _sram_mode_helper(data_out, 2);
 }
 
 uint8_t _sram_transact_helper(uint8_t * data_out, uint8_t len)

--- a/sram.c
+++ b/sram.c
@@ -34,31 +34,6 @@ void sram_init()
   sram_set_mode(BYTE_MODE);
 }
 
-uint8_t _sram_mode_helper(uint8_t * data_out, uint8_t len)
-{
-  spi_set_mode(0, 0);
-
-  uint8_t data_in[len];
-
-  bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-  spi_transact_array(data_out, data_in, len);
-  bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
-
-  return (data_in[len - 1] & MODE_MASK) >> MODE_IDX;
-}
-
-uint8_t sram_read_mode()
-{
-  uint8_t data_out[2] = {RDMR, 0xFF};
-  return _sram_mode_helper(data_out, 2);
-}
-
-void sram_set_mode(enum sram_mode_e mode)
-{
-  uint8_t data_out[2] = {WRMR, mode << MODE_IDX};
-  _sram_mode_helper(data_out, 2);
-}
-
 uint8_t _sram_transact_helper(uint8_t * data_out, uint8_t len)
 {
   /* Transacts the array data_out over SPI to the SRAM IC
@@ -73,6 +48,18 @@ uint8_t _sram_transact_helper(uint8_t * data_out, uint8_t len)
 
   return data_in[len - 1];
 
+}
+
+uint8_t sram_read_mode()
+{
+  uint8_t data_out[2] = {RDMR, 0xFF};
+  return (_sram_transact_helper(data_out, 2) & MODE_MASK) >> MODE_IDX;
+}
+
+void sram_set_mode(enum sram_mode_e mode)
+{
+  uint8_t data_out[2] = {WRMR, mode << MODE_IDX};
+  _sram_transact_helper(data_out, 2);
 }
 
 uint8_t sram_read_byte(uint16_t addr)

--- a/sram.c
+++ b/sram.c
@@ -60,13 +60,12 @@ void sram_set_mode(enum sram_mode_e mode)
   bit_true(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
 }
 
-uint8_t _sram_transact_helper(uint8_t * data_out)
+uint8_t _sram_transact_helper(uint8_t * data_out, uint8_t len)
 {
   /* Transacts the array data_out over SPI to the SRAM IC
      and returns the last byte received. */
   spi_set_mode(0, 0);
 
-  uint8_t len = ARRAY_SIZE(data_out);
   uint8_t data_in[len];
 
   bit_false(SCS_SRAM_PORT, 1 << SCS_SRAM_PIN);
@@ -81,7 +80,7 @@ uint8_t sram_read_byte(uint16_t addr)
 {
   uint8_t data_out[4] = {READ, MSB(addr), LSB(addr), 0xFF};
 
-  return _sram_transact_helper(data_out);
+  return _sram_transact_helper(data_out, 4);
 }
 
 void sram_write_byte(uint16_t addr, uint8_t val)
@@ -89,5 +88,5 @@ void sram_write_byte(uint16_t addr, uint8_t val)
   /* Ignore the return value from _sram_transact_helper */
   uint8_t data_out[4] = {WRITE, MSB(addr), LSB(addr), val};
 
-  _sram_transact_helper(data_out);
+  _sram_transact_helper(data_out, 4);
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/keyme/grbl/pull/118. Not tested (I don't know how to run this code), though it does compile.

- I passed in the length of the array to `_sram_transact_helper`, as discussed in https://github.com/keyme/grbl/pull/118#discussion_r120117307
- I refactored `sram_read_mode` and `sram_set_mode` as discussed in https://github.com/keyme/grbl/pull/118#discussion_r119227733, and passed in the length of the array in a similar manner.