### PR TITLE
SPI: Configure the AVR's SS as an output

### DIFF
--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -21,6 +21,10 @@
 #define SPI_MISO                PB3
 #define SPI_SCK                 PB1
 
+/* MCU SS pin */
+#define AVR_SS_DDR              DDRB
+#define AVR_SS_DDR_BIT          DDB0
+
 //Slave Chip Selects for stepper motors
 #define SCS_XTABLE_PIN          PC6
 #define SCS_YTABLE_PIN          PC5

--- a/spi.c
+++ b/spi.c
@@ -18,6 +18,11 @@ void spi_set_mode(uint8_t cpol, uint8_t cpha)
 void spi_init()
 {
 
+  /* The AVR's SS pin needs to be set to an output. If not,
+  the AVR might operate in slave mode, causing the SPI module
+  not to function as expected */
+  AVR_SS_DDR |= (1 << AVR_SS_DDR_BIT);
+
   /* TODO: Move these chip select initializations to
   their respective drivers. Since we don't have drivers yet,
   disable the CS lines here. */


### PR DESCRIPTION
There was a bug in the way the AVRs SPI is configured. The AVR's SS pin was floating (the input SS pin for when the AVR is in slave mode). It's not connected to anything. 

So when it's floating, the AVR sometimes behaves like it is in slave mode and doesn't drive the clock. The solution is to specify the SS pin as an output.