### PR TITLE
MOTOR: Fix init for old drivers

### DIFF
--- a/main.c
+++ b/main.c
@@ -75,9 +75,9 @@ int main(void)
 
   #ifdef SPI_STEPPER_DRIVER
   spi_init();      // Setup SPI Control register and pins
-  #endif
   motor_drv_init();
   sram_init();
+  #endif
 
   SYS_EXEC = 0;   //and mapped port if different
 

--- a/stepper.c
+++ b/stepper.c
@@ -625,13 +625,10 @@ void keyme_init()
   ESTOP_PORT &= ~(ESTOP_BIT);           //estop input normal-low
 
   // Microstepping
-
-  #ifdef SPI_STEPPER_DRIVER
-    /* TODO: Initialize motor drivers with tables here */
-  #else
+  #ifndef SPI_STEPPER_DRIVER
     MS_DDR = MS_MASK; //all output
     MS_PORT = settings.microsteps & MS_MASK;
-  #endif 
+  #endif
 
   // Phase Current Decay
   PFD_DDR = PFD_MASK; //all output


### PR DESCRIPTION
3.15 did not work for 3.2 kiosks - it wasn't sufficiently tested on old kiosks. This fixes it. I caught this error while testing the binary for a PR to kiosk.

#115 would have fixed this bug. However, before #115 gets merged, https://github.com/keyme/kiosk/pull/10759 is necessary. For https://github.com/keyme/kiosk/pull/10759 to be useful, https://github.com/keyme/grbl/pull/122 first has to be merged because it includes important reporting changes, which means I had to cut a new grbl version (https://github.com/keyme/grbl/pull/123) and add it to the kiosk repo. It was in this step that I found out I broke 4axis for 3.2.

Before this almost circular dependency gets solved, we rely on the SPI flag. This code will be replaced this week once #115 gets in and we release Grbl 4.0, but for now, we need the SPI flag in order for develop to work once we merge the binary just before 4.0. So we will add 3.16 to develop, but 4.0 will replace 3.16 in kiosk before we release new code.

The new reporting updates will make all these dependency headaches go away. Once this goes in, I will cut grbl 3.16 and just go through the steps in the correct order to get the features in without breaking develop.

This cuts keys on 262 (without the SPI flag) and moves axes around on 1700 (with the SPI flag) with command line stepper.