### PR TITLE
VERSION: Roll to 3.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
-VERSION = 0.3.15
+VERSION = 0.3.16
 
 DEVICE     ?= atmega2560
 CLOCK      = 16000000


### PR DESCRIPTION
3.15 (https://github.com/keyme/grbl/pull/123) + one fix (https://github.com/keyme/grbl/pull/124)

Cuts keys on ns263 (3.2) without SPI flag and ns1700 (4.0) with SPI flag.

@Jeff-Ciesielski 