### PR TITLE
VERSION: 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
-VERSION = 0.3.15
+VERSION = 0.4.0
 
 DEVICE     ?= atmega2560
 CLOCK      = 16000000


### PR DESCRIPTION
Since 3.15 (https://github.com/keyme/grbl/pull/123), we added reporting updates and new settings. This new firmware allows us to make settings updates to kiosk and grbl asynchronously.

Cuts keys on 3.2 and 4.0 given the correct eeprom settings.

@Jeff-Ciesielski 