### PR TITLE
DRIVERS: Update adc driver for new verbiage

### DIFF
--- a/adc.c
+++ b/adc.c
@@ -73,11 +73,13 @@ void adc_init()
   // associated peripherals, such as with the stepper motors.
 
 
-  if (settings.use_load_cell) {
+  if (settings.lc_daughter_card) {
+    // Daughter Card load cell conditioner
     LC_DDR &= ~(LC_MASK);
     channel_map[FORCE] = LC_ADC;
   } else {
-    FORCE_DDR &= ~(FORCE_MASK); // Force servo
+    // Onboard load cell conditioner
+    ONBOARD_LC_DDR &= ~(ONBOARD_LC_MASK);
     channel_map[FORCE] = F_ADC;
   }
 

--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -231,10 +231,10 @@
 #define FSCTRL_BIT 5
 
 // Feedback sensor voltage is now analog and called FVOLT
-#define FORCE_DDR DDRK
-#define FORCE_BIT 7
-#define FORCE_PORT PORTK
-#define FORCE_MASK (1 << FORCE_BIT)
+#define ONBOARD_LC_DDR DDRK
+#define ONBOARD_LC_BIT 7
+#define ONBOARD_LC_PORT PORTK
+#define ONBOARD_LC_MASK (1 << ONBOARD_LC_BIT)
 
 // ADC Selection
 #define F_ADC          15 // ADC 15 - Force


### PR DESCRIPTION
We now only use load cells, and the differentiator is where the
conditioning circuit is located (daughter card vs onboard).

@keyme/robotics 