### PR TITLE
FILTERS: Update sample interval to 10ms

### DIFF
--- a/signals.c
+++ b/signals.c
@@ -12,7 +12,7 @@
 #include "systick.h"
 
 #define N_FILTER 3
-#define SIGNALS_DEFAULT_INTERVAL 100
+#define SIGNALS_DEFAULT_INTERVAL 10
 #define X_BUF(i) adc_samples_x[FORCE_VALUE_INDEX][i]
 
 // Unfiltered ADC readings


### PR DESCRIPTION
This should make our ADC readings much more responsive for things like
load cell calibration.

@StephanCoetzee 
Tested on NS1700 during load cell testing.  Gave much more consistent results.