### PR TITLE
DEVICES: Set power MOSFET drivers retry pin low

### DIFF
--- a/cpu_map_keyme2560.h
+++ b/cpu_map_keyme2560.h
@@ -100,7 +100,14 @@
 #define STEPPERS_LONG_LOCK_MASK  ((1<<X_DISABLE_BIT)|(1<<Y_DISABLE_BIT)|(1<<Z_DISABLE_BIT)|(1<<C_DISABLE_BIT))
 #define STEPPERS_LOCK_TIME_MULTIPLE 200  //ms*250 = quarter seconds so 255->63.75s
 
-
+/* OVERCURRENT RETRIES */
+#define OVERCURRENT_RETRY_PORT  PORTD
+#define OVERCURRENT_RETRY_DDR   DDRD
+#define X_AXIS_RETRY_PIN        PD6
+#define Y_AXIS_RETRY_PIN        PD4
+#define Z_AXIS_RETRY_PIN        PD5
+#define C_AXIS_RETRY_PIN        PD7
+#define OVERCURRENT_RETRY_MASK  ((1 << X_AXIS_RETRY_PIN) | (1 << Y_AXIS_RETRY_PIN) | (1 << Z_AXIS_RETRY_PIN) | (1 << C_AXIS_RETRY_PIN))
 
 // NOTE: All limit bit pins must be on the same port
 #define LIMIT_DDR       DDRD

--- a/main.c
+++ b/main.c
@@ -53,6 +53,15 @@ const char* version_string = "VERSION=" XSTR(GRBL_VERSION);
 
 volatile sys_flags_t sysflags;
 
+void set_overcurrent_retries()
+{
+  /* Set as output */
+  OVERCURRENT_RETRY_DDR |= OVERCURRENT_RETRY_MASK;
+
+  /* Set high */
+  OVERCURRENT_RETRY_PORT |= OVERCURRENT_RETRY_MASK;
+}
+
 int main(void)
 {
   // Ensure that the compiler doesn't try to throw out the version string
@@ -71,6 +80,8 @@ int main(void)
   system_init();   // Configure pinout pins and pin-change interrupt
   counters_init(); // Configure encoder and counter interrupt.
   adc_init();
+
+  set_overcurrent_retries();
 
   if (settings.use_spi) {
     /* Setup SPI control register and pins */


### PR DESCRIPTION
@Jeff-Ciesielski 

This configures the power circuit breakers on the PCB to retry immediately after an electrical trip in the field. This change was requested by Erik from Benchmark.

Tested by moving motors.