### PR TITLE
MOTORS: Fix SPI driver re-init after estop release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 #                is connected.
 # FUSES ........ Parameters for avrdude to flash the fuses appropriately.
 
-VERSION = 0.4.3
+VERSION = 0.4.4
 
 DEVICE     ?= atmega2560
 CLOCK      = 16000000


### PR DESCRIPTION
When the ESTOP is released, the motor drivers don't come back into a
useable state.  We need to re-initialize them from scratch to ensure
that the motion control system can proceed as expected.

Tested by engaging/disengaging ESTOP several times, ensuring that machine homes, then cutting several keys (all without restarting)

@keyme/robotics 