### PR TITLE
ALARM: Rename 'Magazine Missing' to 'Carousel dragging'

### DIFF
--- a/magazine.c
+++ b/magazine.c
@@ -99,7 +99,7 @@ void magazine_gap_monitor()
 
   if (delta_pos > mag_state.delta_pos_limit) {
     sys.state = STATE_ALARM;
-    sys.alarm |= ALARM_MAG_MISSING;
+    sys.alarm |= ALARM_CAROUSEL_DRAGGING;
     SYS_EXEC |= (EXEC_FEED_HOLD | EXEC_ALARM | EXEC_CRIT_EVENT);
     st_go_idle();
     protocol_execute_runtime();

--- a/report.c
+++ b/report.c
@@ -120,7 +120,7 @@ void report_alarm_message(int8_t alarm_code)
   if (alarm_code & ALARM_HOME_FAIL)       printPgmString(PSTR("Homing fail "));
   if (alarm_code & ALARM_ESTOP)           printPgmString(PSTR("Estop pressed "));
   if (alarm_code & ALARM_FORCESERVO_FAIL) printPgmString(PSTR("Force servoing fail"));
-  if (alarm_code & ALARM_MAG_MISSING)     printPgmString(PSTR("Magazine Missing"));
+  if (alarm_code & ALARM_CAROUSEL_DRAGGING)     printPgmString(PSTR("Carousel dragging"));
   printPgmString(PSTR("\r\n"));
   delay_ms(500); // Force delay to ensure message clears serial write buffer.
 }

--- a/system.h
+++ b/system.h
@@ -81,7 +81,7 @@
 #define ALARM_HOME_FAIL   bit(4) // home switch transition not found
 #define ALARM_ESTOP       bit(5) // external estop pressed
 #define ALARM_FORCESERVO_FAIL bit(6) // force value not reached while servoing
-#define ALARM_CAROUSEL_DRAGGING  bit(7) //Mag expected but not sensed
+#define ALARM_CAROUSEL_DRAGGING  bit(7) // Mag expected but not sensed
 
 // Define system flags
 #define SYSFLAG_EOL_REPORT bit(0)  // Block is done executing, report linenum

--- a/system.h
+++ b/system.h
@@ -81,7 +81,7 @@
 #define ALARM_HOME_FAIL   bit(4) // home switch transition not found
 #define ALARM_ESTOP       bit(5) // external estop pressed
 #define ALARM_FORCESERVO_FAIL bit(6) // force value not reached while servoing
-#define ALARM_MAG_MISSING  bit(7) //Mag expected but not sensed
+#define ALARM_CAROUSEL_DRAGGING  bit(7) //Mag expected but not sensed
 
 // Define system flags
 #define SYSFLAG_EOL_REPORT bit(0)  // Block is done executing, report linenum


### PR DESCRIPTION
Tested with a new branch of kiosk that will go in once we roll the new Grbl.
Tested by adjusting the magazine gap limit setting in the eeprom, thereby forcing the alarm. Also tested it without forcing the alarm to cut keys.


@keyme/robotics 