### PR TITLE
GRBL: Fix force servo line number reporting

### DIFF
--- a/limits.c
+++ b/limits.c
@@ -409,6 +409,10 @@ void limits_force_servo()
   // delay for LONG_FORCE_SERVO_DELAY ms 
   delay = LONG_FORCE_SERVO_DELAY;
 
+  linenumber_insert(LINENUMBER_SPECIAL_SERVO | ((servo_line_number * 4) + FORCE_SERVO_START));
+  request_eol_report();
+  protocol_execute_runtime();
+
   // Perform force servoing cyles
   do {
     // Stay in this loop while moving the gripper motor
@@ -434,8 +438,7 @@ void limits_force_servo()
     limits_disable();
     st_reset(); // Immediately force kill steppers and reset step segment buffer.
     plan_reset(); // Reset planner buffer. Zero planner positions. Ensure homing motion is cleared.
-
-    linenumber_insert(LINENUMBER_SPECIAL_SERVO | ((servo_line_number * 4) + LINEMASK_DONE));
+    linenumber_insert(LINENUMBER_SPECIAL_SERVO | ((servo_line_number * 4) + FORCE_SERVO_BUSY));
     request_eol_report();
     protocol_execute_runtime();
     request_eol_report(); // Need to report once more to report the "DONE" linenumber
@@ -457,7 +460,11 @@ void limits_force_servo()
     delay = SHORT_FORCE_SERVO_DELAY;
      
   } while ((cycles <= MIN_FORCE_SERVO_CYCLES) | ((cycles <= MAX_FORCE_SERVO_CYCLES) \
-          && (abs(limits.bump_grip_force - FORCE_VAL) > GRIPPER_FORCE_THRESHOLD)));  
+          && (abs(limits.bump_grip_force - FORCE_VAL) > GRIPPER_FORCE_THRESHOLD)));
+
+  linenumber_insert(LINENUMBER_SPECIAL_SERVO | ((servo_line_number * 4) + FORCE_SERVO_DONE));
+  request_eol_report();
+  protocol_execute_runtime();
 
   // Resume the regular sampling of ADCs
   signals.pause = 0;

--- a/system.h
+++ b/system.h
@@ -150,9 +150,13 @@ void system_execute_startup(char *line);
 
 #define LINENUMBER_SPECIAL_SERVO 0x10000 //denotes force servoing
 #define LINENUMBER_MAX         (LINENUMBER_SPECIAL-1)
-#define LINEMASK_OFF_EDGE         (0x0)
-#define LINEMASK_ON_EDGE         (0x1)
-#define LINEMASK_DONE           (0x2)
+#define LINEMASK_OFF_EDGE (0x0)
+#define LINEMASK_ON_EDGE  (0x1)
+#define LINEMASK_DONE     (0x2)
+#define FORCE_SERVO_START (0x0)
+#define FORCE_SERVO_BUSY  (0x1)
+#define FORCE_SERVO_DONE  (0x2)
+
 typedef uint32_t linenumber_t;
 
 


### PR DESCRIPTION
This was originally meant to mirror the homing line numbering, however
the bitmasks were incorrectly used, leading to weird behavior upstream.

Tested on NS1086 (with requisite python changes).  Works as intended.

@keyme/robotics 